### PR TITLE
HSD8-549 Allow users to choose which embed player to use

### DIFF
--- a/src/Plugin/MediaEmbedDialog/File.php
+++ b/src/Plugin/MediaEmbedDialog/File.php
@@ -49,7 +49,6 @@ class File extends MediaEmbedDialogBase {
   public function preRender(array $element) {
     $source_field = static::getMediaSourceField($element['#media']);
     $element[$source_field][0]['#description'] = $element['#display_settings']['description'];
-    $element['#cache']['max-age'] = 0;
     return $element;
   }
 

--- a/src/Plugin/MediaEmbedDialog/SoundCloud.php
+++ b/src/Plugin/MediaEmbedDialog/SoundCloud.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\stanford_media\Plugin\MediaEmbedDialog;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\media\MediaInterface;
+use Drupal\stanford_media\Plugin\MediaEmbedDialogBase;
+use Drupal\stanford_media\Plugin\MediaEmbedDialogInterface;
+
+/**
+ * Changes embedded file media items.
+ *
+ * @MediaEmbedDialog(
+ *   id = "soundcloud",
+ *   media_type = "audio"
+ * )
+ */
+class SoundCloud extends MediaEmbedDialogBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isApplicable() {
+    if ($this->entity instanceof MediaInterface && $this->entity->bundle() == 'audio') {
+      $source_field = static::getMediaSourceField($this->entity);
+      $field_value = $this->entity->get($source_field)->getString();
+      return strpos($field_value, 'soundcloud') !== FALSE;
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterDialogForm(array &$form, FormStateInterface $form_state) {
+    parent::alterDialogForm($form, $form_state);
+    // Restore caption text field.
+    $form['attributes']['data-caption']['#type'] = 'textfield';
+    $input = $this->getUserInput($form_state);
+
+    $form['attributes'][MediaEmbedDialogInterface::SETTINGS_KEY]['style'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Style'),
+      '#description' => $this->t('Choose which style of embed player to use.'),
+      '#default_value' => $input['style'] ?: 'classic',
+      '#options' => [
+        'classic' => $this->t('Classic Embed'),
+        'visual' => $this->t('Visual Embed'),
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preRender(array $element) {
+    if ($element['#display_settings']['style'] == 'classic') {
+      $source_field = static::getMediaSourceField($element['#media']);
+      $element[$source_field][0]['children']['#query']['visual'] = 'false';
+    }
+    return $element;
+  }
+
+}

--- a/src/Plugin/MediaEmbedDialog/SoundCloud.php
+++ b/src/Plugin/MediaEmbedDialog/SoundCloud.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\stanford_media\Plugin\MediaEmbedDialog;
 
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\media\MediaInterface;
 use Drupal\stanford_media\Plugin\MediaEmbedDialogBase;
@@ -24,7 +25,12 @@ class SoundCloud extends MediaEmbedDialogBase {
     if ($this->entity instanceof MediaInterface && $this->entity->bundle() == 'audio') {
       $source_field = static::getMediaSourceField($this->entity);
       $field_value = $this->entity->get($source_field)->getString();
-      return strpos($field_value, 'soundcloud') !== FALSE;
+      if (!UrlHelper::isValid($field_value)) {
+        return FALSE;
+      }
+
+      $url = parse_url($field_value);
+      return isset($url['host']) && $url['host'] == 'soundcloud.com';
     }
     return FALSE;
   }

--- a/src/Plugin/audio_embed_field/Provider/StanfordSoundCloud.php
+++ b/src/Plugin/audio_embed_field/Provider/StanfordSoundCloud.php
@@ -37,8 +37,7 @@ class StanfordSoundCloud extends SoundCloud {
    * {@inheritdoc}
    */
   public static function getIdFromInput($input) {
-    $video_data = static::getVideoData($input);
-    if (!$video_data) {
+    if (!$input || !($video_data = static::getVideoData($input))) {
       return NULL;
     }
 
@@ -84,10 +83,6 @@ class StanfordSoundCloud extends SoundCloud {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   protected static function getVideoData($video_url) {
-    if (!$video_url) {
-      return NULL;
-    }
-
     $cache = \Drupal::cache('default');
     if ($cache_item = $cache->get('audio_embed_field:' . md5($video_url))) {
       return $cache_item->data;

--- a/src/Plugin/audio_embed_field/Provider/StanfordSoundCloud.php
+++ b/src/Plugin/audio_embed_field/Provider/StanfordSoundCloud.php
@@ -58,6 +58,21 @@ class StanfordSoundCloud extends SoundCloud {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function renderEmbedCode($width, $height, $autoplay) {
+    $render = parent::renderEmbedCode($width, $height, $autoplay);
+    $video_data = static::getVideoData($this->input);
+
+    // Fix the url if the input is actually a playlist instead of a track.
+    if (strpos($video_data['html'], 'playlist') !== FALSE) {
+      $render['#url'] = str_replace('/tracks/', '/playlists/', $render['#url']);
+    }
+
+    return $render;
+  }
+
+  /**
    * Get data array from SoundCloud for a share url.
    *
    * @param string $video_url
@@ -69,6 +84,10 @@ class StanfordSoundCloud extends SoundCloud {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   protected static function getVideoData($video_url) {
+    if (!$video_url) {
+      return NULL;
+    }
+
     $cache = \Drupal::cache('default');
     if ($cache_item = $cache->get('audio_embed_field:' . md5($video_url))) {
       return $cache_item->data;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow users to choose which embed player to use

# Needed By (Date)
- Someday

# Urgency
- Low

# Steps to Test
1. Embed a soundcloud audio
1. ensure "Classic Embed" and "Visual Embed" radio button are visible and function as expected.


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)