### PR TITLE
HSD8-309 Ignore revisions for used in count on media list

### DIFF
--- a/config/install/views.view.media_entity_browser.yml
+++ b/config/install/views.view.media_entity_browser.yml
@@ -14,6 +14,8 @@ dependencies:
     - media
     - stanford_media
     - user
+_core:
+  default_config_hash: NKBRSiKezewod-OhOplqzbRLwzt2ki1vtFBKlvunIuU
 id: media_entity_browser
 label: 'Stanford Media'
 module: views
@@ -416,15 +418,19 @@ display:
         - url.query_args
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.media.audio.default'
+        - extensions
+        - 'config:core.entity_view_display.media.audio.full'
+        - extensions
         - 'config:core.entity_view_display.media.file.default'
-        - extensions
-        - 'config:core.entity_view_display.media.image.default'
-        - extensions
-        - 'config:core.entity_view_display.media.image.thumbnail'
         - extensions
         - 'config:core.entity_view_display.media.video.default'
         - extensions
         - 'config:core.entity_view_display.media.video.full'
+        - extensions
+        - 'config:core.entity_view_display.media.image.default'
+        - extensions
+        - 'config:core.entity_view_display.media.image.thumbnail'
         - extensions
   file_browser:
     display_plugin: entity_browser
@@ -552,6 +558,10 @@ display:
         - url.query_args
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.media.audio.default'
+        - extensions
+        - 'config:core.entity_view_display.media.audio.full'
+        - extensions
         - 'config:core.entity_view_display.media.file.default'
         - extensions
         - 'config:core.entity_view_display.media.image.default'
@@ -688,6 +698,10 @@ display:
         - url.query_args
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.media.audio.default'
+        - extensions
+        - 'config:core.entity_view_display.media.audio.full'
+        - extensions
         - 'config:core.entity_view_display.media.file.default'
         - extensions
         - 'config:core.entity_view_display.media.image.default'
@@ -722,6 +736,10 @@ display:
         - url.query_args
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.media.audio.default'
+        - extensions
+        - 'config:core.entity_view_display.media.audio.full'
+        - extensions
         - 'config:core.entity_view_display.media.file.default'
         - extensions
         - 'config:core.entity_view_display.media.image.default'
@@ -796,7 +814,7 @@ display:
           table: entity_usage
           field: count
           relationship: media_to_usage_entity
-          group_type: group
+          group_type: count
           admin_label: ''
           label: Uses
           exclude: false
@@ -860,6 +878,7 @@ display:
         style: false
         row: false
         access: false
+        group_by: false
       arguments:
         mid:
           id: mid
@@ -974,6 +993,7 @@ display:
         type: perm
         options:
           perm: 'access media overview'
+      group_by: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -1510,12 +1530,12 @@ display:
           entity_type: media
           entity_field: changed
           plugin_id: field
-        count:
-          id: count
+        source_id:
+          id: source_id
           table: entity_usage
-          field: count
+          field: source_id
           relationship: media_to_usage_entity
-          group_type: sum
+          group_type: count_distinct
           admin_label: ''
           label: 'Used In'
           exclude: false
@@ -1565,7 +1585,7 @@ display:
           format_plural: false
           format_plural_string: !!binary MQNAY291bnQ=
           prefix: ''
-          suffix: ' Places'
+          suffix: ''
           plugin_id: numeric
         operations:
           id: operations
@@ -1735,11 +1755,11 @@ display:
             rendered_entity: rendered_entity
             name: name
             bundle: bundle
+            field_media_image: field_media_image
             uid: uid
             changed: changed
             count: count
             operations: operations
-            field_media_image: field_media_image
           info:
             media_bulk_form:
               align: ''
@@ -1774,6 +1794,13 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
+            field_media_image:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
             uid:
               sortable: true
               default_sort_order: asc
@@ -1800,13 +1827,6 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-            field_media_image:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: true
-              responsive: ''
           default: changed
           empty_table: false
       row:
@@ -1829,6 +1849,8 @@ display:
         - url.query_args
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.media.audio.default'
+        - 'config:core.entity_view_display.media.audio.full'
         - 'config:core.entity_view_display.media.file.default'
         - 'config:core.entity_view_display.media.image.default'
         - 'config:core.entity_view_display.media.image.thumbnail'
@@ -1962,6 +1984,10 @@ display:
         - url.query_args
         - user.permissions
       tags:
+        - 'config:core.entity_view_display.media.audio.default'
+        - extensions
+        - 'config:core.entity_view_display.media.audio.full'
+        - extensions
         - 'config:core.entity_view_display.media.file.default'
         - extensions
         - 'config:core.entity_view_display.media.image.default'

--- a/stanford_media.install
+++ b/stanford_media.install
@@ -5,9 +5,33 @@
  * stanford_media.install
  */
 
+use Drupal\views\Entity\View;
+
 /**
  * Enable new submodule.
  */
 function stanford_media_update_8001() {
   \Drupal::service('module_installer')->install(['media_duplicate_validation']);
+}
+
+/**
+ * Update the media view.
+ */
+function stanford_media_update_8002() {
+  $view = View::load('media_entity_browser');
+  $list_display = &$view->getDisplay('use_list');
+  $list_display['display_options']['fields']['source_id'] = [
+    'id' => 'source_id',
+    'field' => 'source_id',
+    'group_type' => 'count_distinct',
+  ];
+  $list_display['display_options']['fields']['source_id'] += $list_display['display_options']['fields']['count'];
+  unset($list_display['display_options']['fields']['count']);
+
+  // Move operations column to the end.
+  $operations = $list_display['display_options']['fields']['operations'];
+  unset($list_display['display_options']['fields']['operations']);
+  $list_display['display_options']['fields']['operations'] = $operations;
+
+  $view->save();
 }

--- a/stanford_media.views.inc
+++ b/stanford_media.views.inc
@@ -16,6 +16,22 @@ function stanford_media_views_data_alter(array &$data) {
       'id' => 'entity_usage_link',
     ],
   ];
+  $data['entity_usage']['source_id'] = [
+    'title' => t('Usage Source ID'),
+    'help' => t('The Entity Source ID using the entity.'),
+    'field' => [
+      'id' => 'numeric',
+    ],
+    'sort' => [
+      'id' => 'standard',
+    ],
+    'filter' => [
+      'id' => 'numeric',
+    ],
+    'argument' => [
+      'id' => 'numeric',
+    ],
+  ];
 
   return $data;
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added view field for source_id from entity usage data
- replaced the usage count with the new source_id, applied aggregation. this eliminated the count on revisions for each entity.
- If a media item is used in different paragraphs, it will count each of those separately still.
- see https://github.com/SU-HSDO/suhumsci/pull/155

# Needed By (Date)
- Some day.

# Urgency
- Low

# Steps to Test

1.Checkout this branch
1. update database
1. create a new page and add a new image/file to it.
1. edit and save (no changes to the node) several times
1. view /admin/content/media page and ensure it shows only 1 use count instead of multiple


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)