### PR TITLE
Prevent php notice by faking another field data

### DIFF
--- a/src/Form/MediaLibraryFileUploadForm.php
+++ b/src/Form/MediaLibraryFileUploadForm.php
@@ -190,6 +190,7 @@ class MediaLibraryFileUploadForm extends FileUploadForm {
         '#attached' => ['library' => ['stanford_media/admin']],
         '#prefix' => '<div class="similar-media-options">',
         '#suffix' => '</div>',
+        'fields' => ['#source_field_name' => ''],
       ];
     }
     return $element;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixup to prevent php error of undefined index.

# Need Review By (Date)
- eventually

# Urgency
- low

# Steps to Test
1. add an image to any content type or wysiwyg
1. review database logs for errors about undefined index `#source_field_name` (several errors come from an [issue in core](https://www.drupal.org/project/drupal/issues/3094397)
1. checkout this branch
1. clear database logs
1. repeat above steps
1. review the `#source_field_name` error is gone

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
