### PR TITLE
8.2.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,21 @@
 # Stanford Media
 
+8.x-2.0-alpha2
+--------------------------------------------------------------------------------
+_Release Date: 2020-01-22_
+
+- check for entities before deleting them in update process
+- Patch focal point for use in media library (#27)
+- Dont set responsive image style for non-images
+- Bugfix: Prevent php notice by faking another field data (#25)
+- D8CORE-638 D8CORE-801 Tweaks to WYSIWYG media (#26)
+- changed weekly tests to correct branch
+- D8CORE-334: Update responsive breakpoints and image styles. (#23)
+- Update stanford_media.info.yml
+
+
 8.x-2.0-alpha1
---------------------------------------------------------------------------------  
+--------------------------------------------------------------------------------
 _Release Date: 2019-10-30_
 
 - Initial Release using Drupal Core media in 8.8.

--- a/modules/media_duplicate_validation/media_duplicate_validation.info.yml
+++ b/modules/media_duplicate_validation/media_duplicate_validation.info.yml
@@ -1,7 +1,7 @@
 name: 'Media Duplicate Validation'
 type: module
 description: 'Media Validation plugins to help prevent duplication of media items'
-core: 8.x
+core: 8.2.0-alpha2
 package: 'Custom'
 dependencies:
   - drupal:media

--- a/modules/media_duplicate_validation/media_duplicate_validation.info.yml
+++ b/modules/media_duplicate_validation/media_duplicate_validation.info.yml
@@ -1,7 +1,8 @@
 name: 'Media Duplicate Validation'
 type: module
 description: 'Media Validation plugins to help prevent duplication of media items'
-core: 8.2.0-alpha2
-package: 'Custom'
+core_version_requirement: ^8.8 || ^9
+version: 8.2.0-alpha2
+package: media
 dependencies:
   - drupal:media

--- a/stanford_media.info.yml
+++ b/stanford_media.info.yml
@@ -3,7 +3,7 @@ description: Provides media module configuration and plugins.
 core_version_requirement: ^8.8 || ^9
 package: media
 type: module
-version: 8.x-2.0-dev
+version: 8.x-2.0-alpha2
 dependencies:
   - dropzonejs:dropzonejs
   - drupal:breakpoint


### PR DESCRIPTION
# What (Changelog)
- Updated responsive breakpoints to match decanter's
- added some styles to ckeditor
- patched focal point contrib and updated the image media type to make use of it.
- Fixed older update hook for some sites.

# So what
- Ckeditor text looks better.
- Media in the ckeditor will have a more obvious "Edit media" button.

# Now what
- Deploy and run update hook.

# New Requirements and Risks (Changelog)
- none

# Diff
- https://github.com/SU-SWS/stanford_media/compare/8.x-2.0-alpha1..8.2.0-alpha.2