### PR TITLE
D8CORE-1343 Use Media name if no description is provided

### DIFF
--- a/stanford_media.module
+++ b/stanford_media.module
@@ -98,3 +98,21 @@ function stanford_media_preprocess_dropzonejs(&$variables) {
   // Adds additional things to the template for the dropzone js widget.
   $variables['allowed_files'] = str_replace(' ', ', ', $variables['element']['#extensions']);
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function stanford_media_preprocess_media(&$variables) {
+
+  /** @var \Drupal\media\MediaInterface $media */
+  $media = $variables['media'];
+  if ($media->getSource()->getPluginId() != 'file') {
+    return;
+  }
+  $media_type = \Drupal::entityTypeManager()->getStorage('media_type')->load($media->bundle());
+  $source_field = $media->getSource()->getSourceFieldDefinition($media_type)->getName();
+
+  if (empty($variables['content'][$source_field][0]['#description'])) {
+    $variables['content'][$source_field][0]['#description'] = $variables['name'];
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- If a file media type is embed but doesnt have a "Description" provided, make sure to use the media entity's title.

# Need Review By (Date)
- 2/28

# Urgency
- low

# Steps to Test
1. Checkout this branch
1. clear cache
1. embed a document in a wysiwyg and change the name of the media item after upload.
1. in the wysiwyg click to edit the media item and remove all text from the "Description" field
1. Save and validate the media link is what you named the media entity.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
