### PR TITLE
D8CORE-1409: Remove duplicate source tag from embedded media.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ code_coverage: &code_coverage
         name: Run PHP Unit Coverage Tests
         command: |
           composer global require SU-SWS/stanford-caravan:dev-8.x-1.x
-          ~/.composer/vendor/bin/sws-caravan phpunit /var/www/html --extension-dir=/var/www/test --with-coverage --latest-drupal
+          ~/.composer/vendor/bin/sws-caravan phpunit /var/www/html --extension-dir=/var/www/test --with-coverage
     - save_cache:
         key: dependencies-{{ epoch }}
         paths:
@@ -47,7 +47,7 @@ behat: &behat
         name: Run Behat Tests
         command: |
           composer global require SU-SWS/stanford-caravan:dev-8.x-1.x
-          ~/.composer/vendor/bin/sws-caravan behat /var/www/html --extension-dir=/var/www/test --latest-drupal
+          ~/.composer/vendor/bin/sws-caravan behat /var/www/html --extension-dir=/var/www/test
     - save_cache:
         key: dependencies-{{ epoch }}
         paths:

--- a/src/Plugin/Filter/MediaEmbedMarkupFilter.php
+++ b/src/Plugin/Filter/MediaEmbedMarkupFilter.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @file
+ *
+ * This filter is to remedy issues with libxml2 and core issues.
+ * https://www.drupal.org/project/drupal/issues/1333730
+ */
+
+namespace Drupal\stanford_media\Plugin\Filter;
+
+use Drupal\filter\Plugin\FilterBase;
+use Drupal\filter\FilterProcessResult;
+
+/**
+ * @Filter(
+ *   id = "stanford_media_embed_markup",
+ *   title = @Translation("Stanford Media Embed Filter"),
+ *   description = @Translation("This helps with core markup issues. This filter has to run after the Embed Media filter."),
+ *   type = Drupal\filter\Plugin\FilterInterface::TYPE_MARKUP_LANGUAGE,
+ * )
+ */
+class MediaEmbedMarkupFilter extends FilterBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function process($text, $langcode) {
+    $new_text = preg_replace('/><\/source>/m', "/>", $text);
+    return new FilterProcessResult($new_text);
+  }
+
+}

--- a/src/Plugin/Filter/MediaEmbedMarkupFilter.php
+++ b/src/Plugin/Filter/MediaEmbedMarkupFilter.php
@@ -6,6 +6,8 @@ use Drupal\filter\Plugin\FilterBase;
 use Drupal\filter\FilterProcessResult;
 
 /**
+ * MediaEmbedMarkupFilter for fixing core issues.
+ *
  * @Filter(
  *   id = "stanford_media_embed_markup",
  *   title = @Translation("Stanford Media Embed Filter"),

--- a/src/Plugin/Filter/MediaEmbedMarkupFilter.php
+++ b/src/Plugin/Filter/MediaEmbedMarkupFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-/**
- * Text Editor Filters.
- *
- * This filter is to remedy issues with libxml2 and core issues.
- * https://www.drupal.org/project/drupal/issues/1333730.
- */
+//
+// Text Editor Filters.
+//
+// This filter is to remedy issues with libxml2 and core issues.
+// https://www.drupal.org/project/drupal/issues/1333730.
+//
 
 namespace Drupal\stanford_media\Plugin\Filter;
 

--- a/src/Plugin/Filter/MediaEmbedMarkupFilter.php
+++ b/src/Plugin/Filter/MediaEmbedMarkupFilter.php
@@ -1,9 +1,10 @@
 <?php
+
 /**
- * @file
+ * Text Editor Filters.
  *
  * This filter is to remedy issues with libxml2 and core issues.
- * https://www.drupal.org/project/drupal/issues/1333730
+ * https://www.drupal.org/project/drupal/issues/1333730.
  */
 
 namespace Drupal\stanford_media\Plugin\Filter;
@@ -22,7 +23,7 @@ use Drupal\filter\FilterProcessResult;
 class MediaEmbedMarkupFilter extends FilterBase {
 
   /**
-   * {@inheritDoc}
+   * {@inheritdoc}
    */
   public function process($text, $langcode) {
     $new_text = preg_replace('/><\/source>/m', "/>", $text);

--- a/src/Plugin/Filter/MediaEmbedMarkupFilter.php
+++ b/src/Plugin/Filter/MediaEmbedMarkupFilter.php
@@ -1,12 +1,5 @@
 <?php
 
-//
-// Text Editor Filters.
-//
-// This filter is to remedy issues with libxml2 and core issues.
-// https://www.drupal.org/project/drupal/issues/1333730.
-//
-
 namespace Drupal\stanford_media\Plugin\Filter;
 
 use Drupal\filter\Plugin\FilterBase;
@@ -26,6 +19,9 @@ class MediaEmbedMarkupFilter extends FilterBase {
    * {@inheritdoc}
    */
   public function process($text, $langcode) {
+
+    // This filter is to remedy issues with libxml2 and core issues.
+    // https://www.drupal.org/project/drupal/issues/1333730.
     $new_text = preg_replace('/><\/source>/m', "/>", $text);
     return new FilterProcessResult($new_text);
   }

--- a/tests/src/Kernel/Plugin/Filter/MediaEmbedMarkupFilterTest.php
+++ b/tests/src/Kernel/Plugin/Filter/MediaEmbedMarkupFilterTest.php
@@ -59,18 +59,18 @@ class MediaEmbedMarkupFilterTest extends MediaEmbedFilterTestBase {
       ])
       ->addImageStyleMapping('responsive_image_test_module.mobile', '1x', [
         'image_mapping_type' => 'image_style',
-        'image_mapping' => 'small',
+        'image_mapping' => '',
       ])
       ->addImageStyleMapping('responsive_image_test_module.narrow', '1x', [
         'image_mapping_type' => 'sizes',
         'image_mapping' => [
           'sizes' => '(min-width: 700px) 700px, 100vw',
-          'sizes_image_styles' => ['medium'],
+          'sizes_image_styles' => [],
         ],
       ])
       ->addImageStyleMapping('responsive_image_test_module.wide', '1x', [
         'image_mapping_type' => 'image_style',
-        'image_mapping' => 'large',
+        'image_mapping' => '',
       ])
       ->save();
 

--- a/tests/src/Kernel/Plugin/Filter/MediaEmbedMarkupFilterTest.php
+++ b/tests/src/Kernel/Plugin/Filter/MediaEmbedMarkupFilterTest.php
@@ -11,6 +11,8 @@ use Drupal\Core\Entity\Entity\EntityViewDisplay;
 use Drupal\Core\Entity\Entity\EntityViewMode;
 
 /**
+ * MediaEmbedMarkupFilter Tests.
+ *
  * @coversDefaultClass \Drupal\stanford_media\Plugin\Filter\MediaEmbedMarkupFilter
  * @group stanford_media
  */
@@ -37,12 +39,6 @@ class MediaEmbedMarkupFilterTest extends MediaEmbedFilterTestBase {
   ];
 
   /**
-   * @var \Drupal\responsive_image\Entity\ResponsiveImageStyle
-   */
-  protected $RImgStyle;
-
-
-  /**
    * Test the filter.
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
@@ -63,18 +59,18 @@ class MediaEmbedMarkupFilterTest extends MediaEmbedFilterTestBase {
       ])
       ->addImageStyleMapping('responsive_image_test_module.mobile', '1x', [
         'image_mapping_type' => 'image_style',
-        'image_mapping' => '',
+        'image_mapping' => 'small',
       ])
       ->addImageStyleMapping('responsive_image_test_module.narrow', '1x', [
         'image_mapping_type' => 'sizes',
         'image_mapping' => [
           'sizes' => '(min-width: 700px) 700px, 100vw',
-          'sizes_image_styles' => [],
+          'sizes_image_styles' => ['medium'],
         ],
       ])
       ->addImageStyleMapping('responsive_image_test_module.wide', '1x', [
         'image_mapping_type' => 'image_style',
-        'image_mapping' => '',
+        'image_mapping' => 'large',
       ])
       ->save();
 

--- a/tests/src/Kernel/Plugin/Filter/MediaEmbedMarkupFilterTest.php
+++ b/tests/src/Kernel/Plugin/Filter/MediaEmbedMarkupFilterTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * @file
+ */
+
+namespace Drupal\Tests\stanford_media\Kernel\Plugin\Filter;
+
+use Drupal\Tests\media\Kernel\MediaEmbedFilterTestBase;
+use Drupal\responsive_image\Entity\ResponsiveImageStyle;
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
+use Drupal\Core\Entity\Entity\EntityViewMode;
+
+/**
+ * @coversDefaultClass \Drupal\stanford_media\Plugin\Filter\MediaEmbedMarkupFilter
+ * @group stanford_media
+ */
+class MediaEmbedMarkupFilterTest extends MediaEmbedFilterTestBase {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'field',
+    'file',
+    'filter',
+    'image',
+    'media',
+    'system',
+    'text',
+    'user',
+    'entity_reference',
+    'breakpoint',
+    'responsive_image',
+    'responsive_image_test_module',
+    'stanford_media',
+  ];
+
+  /**
+   * @var \Drupal\responsive_image\Entity\ResponsiveImageStyle
+   */
+  protected $RImgStyle;
+
+
+  /**
+   * Test the filter.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testFilterMarkup() {
+    $embed_attributes = [
+      'data-entity-type' => 'media',
+      'data-entity-uuid' => static::EMBEDDED_ENTITY_UUID,
+      'data-view-mode' => 'dupededupe',
+    ];
+
+    // Create Responsive Image Style.
+    ResponsiveImageStyle::create([
+      'id' => 'full',
+      'label' => 'full',
+      'breakpoint_group' => 'responsive_image_test_module',
+      'fallback_image_style' => 'large',
+      ])
+      ->addImageStyleMapping('responsive_image_test_module.mobile', '1x', [
+        'image_mapping_type' => 'image_style',
+        'image_mapping' => '',
+      ])
+      ->addImageStyleMapping('responsive_image_test_module.narrow', '1x', [
+        'image_mapping_type' => 'sizes',
+        'image_mapping' => [
+          'sizes' => '(min-width: 700px) 700px, 100vw',
+          'sizes_image_styles' => [],
+        ],
+      ])
+      ->addImageStyleMapping('responsive_image_test_module.wide', '1x', [
+        'image_mapping_type' => 'image_style',
+        'image_mapping' => '',
+      ])
+      ->save();
+
+    EntityViewMode::create([
+      'id' => 'media.dupededupe',
+      'targetEntityType' => 'media',
+      'status' => TRUE,
+      'enabled' => TRUE,
+      'label' => $this->randomMachineName(),
+    ])->save();
+
+    EntityViewDisplay::create([
+      'targetEntityType' => 'media',
+      'bundle' => 'image',
+      'mode' => 'dupededupe',
+      'status' => TRUE,
+    ])->removeComponent('thumbnail')
+      ->removeComponent('created')
+      ->removeComponent('uid')
+      ->setComponent('field_media_image', [
+        'label' => 'visually_hidden',
+        'type' => 'responsive_image',
+        'settings' => [
+          'responsive_image_style' => 'full',
+          'image_link' => '',
+        ],
+        'third_party_settings' => [],
+        'weight' => 1,
+        'region' => 'content',
+      ])
+      ->save();
+
+    $content = $this->createEmbedCode($embed_attributes);
+    $filter_result = $this->processText($content, "en", ['media_embed', 'stanford_media_embed_markup']);
+    $output = $filter_result->getProcessedText();
+
+    $this->assertNotContains("</source>", $output);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Text editor filter to fix a core issue. 
- Responsive images in the text editor are outputting `<source ..></source>` which is invalid html as the libxml2 library does not support new html5 tags. 
- see: https://www.drupal.org/project/drupal/issues/1333730
- As of 01/31/2020 there has been no movement in the library to support html5
- This PR adds a filter that we can add to the text formats to do the manual string manipulation on the generated output to correct that.

# Review By (Date)
- End of the month (feb)

# Urgency
- Low, as stuff still works but validators don't like it.

# Steps to Test

1. Check out this branch in our local build of `stanford_profile` 
2. Navigate to and enable the new option in the HTML format `/admin/config/content/formats/manage/stanford_html`
3. Create a new basic page with a WYSIWYG paragraph and insert an image with default settings
4. Save page and view source (not in inspector as that will lie to you.)
5. Validate the `<source>` tag is self-closing.

# Affected Projects or Products
- D8Core and anything that uses Media

# Associated Issues and/or People
- D8CORE-1409
- https://github.com/SU-SWS/acsf-cardinald7/tree/1.x/docroot/profiles/stanford
- @boznik 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)