### PR TITLE
8.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Stanford Media
 
+8.x-2.1
+--------------------------------------------------------------------------------
+_Release Date: 2020-02-21_
+
+- HSD8-758 Fixed number of items available when the field is unlimited
+- D8CORE-1343 Use Media name if no description is provided
+- D8CORE-1392 Added padding to aligned images
+- D8CORE-1409: Remove duplicate source tag from embedded media.
+
 8.x-2.0
 --------------------------------------------------------------------------------
 _Release Date: 2020-02-19_

--- a/modules/media_duplicate_validation/media_duplicate_validation.info.yml
+++ b/modules/media_duplicate_validation/media_duplicate_validation.info.yml
@@ -2,7 +2,7 @@ name: 'Media Duplicate Validation'
 type: module
 description: 'Media Validation plugins to help prevent duplication of media items'
 core_version_requirement: ^8.8 || ^9
-version: 8.x-2.0
+version: 8.x-2.1
 package: media
 dependencies:
   - drupal:media

--- a/stanford_media.info.yml
+++ b/stanford_media.info.yml
@@ -3,7 +3,7 @@ description: Provides media module configuration and plugins.
 core_version_requirement: ^8.8 || ^9
 package: media
 type: module
-version: 8.x-2.1-dev
+version: 8.x-2.1
 dependencies:
   - dropzonejs:dropzonejs
   - drupal:breakpoint


### PR DESCRIPTION
```
# What
- HSD8-758 Fixed number of items available when the field is unlimited
- D8CORE-1343 Use Media name if no description is provided
- D8CORE-1392 Added padding to aligned images
- D8CORE-1409: Remove duplicate source tag from embedded media.

# So what
- If a field allows unlimited media items, the user can upload successfully.
- If the user doesn't provide a custom link text for a file, the media title will be used
- Images have some space. They are sensitive
- A new wysiwyg filter is available that adjusts `<source>` tags to be self closing.

# Now what
- Deploy & Clear cache 
- Modify a text format to use the new filter if desired.

# New Requirements and Risks
- None
```