### PR TITLE
D8CORE-1026 D8CORE-1516 Fix error in field formatters

### DIFF
--- a/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
@@ -33,6 +33,10 @@ class MediaImageFormatter extends MediaImageFormatterBase {
   public function preRender($element) {
     $source_field = self::getSourceField($element['#media']);
 
+    if (empty($element[$source_field]['#field_type']) || $element[$source_field]['#field_type'] != 'image') {
+      return $element;
+    }
+
     $element[$source_field]['#formatter'] = 'image';
     foreach (Element::children($element[$source_field]) as $delta) {
       $item = &$element[$source_field][$delta];

--- a/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
@@ -30,7 +30,7 @@ class MediaImageFormatter extends MediaImageFormatterBase {
   /**
    * {@inheritdoc}
    */
-  public function preRender($element) {
+  public static function preRender($element) {
     $source_field = self::getSourceField($element['#media']);
 
     // If the field isn't an image, don't do anything.

--- a/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
@@ -33,6 +33,7 @@ class MediaImageFormatter extends MediaImageFormatterBase {
   public function preRender($element) {
     $source_field = self::getSourceField($element['#media']);
 
+    // If the field isn't an image, don't do anything.
     if (empty($element[$source_field]['#field_type']) || $element[$source_field]['#field_type'] != 'image') {
       return $element;
     }

--- a/src/Plugin/Field/FieldFormatter/MediaImageFormatterBase.php
+++ b/src/Plugin/Field/FieldFormatter/MediaImageFormatterBase.php
@@ -127,6 +127,6 @@ abstract class MediaImageFormatterBase extends MediaFormatterBase implements Tru
    * @return array
    *   Altered render array.
    */
-  abstract public function preRender($element);
+  abstract public static function preRender($element);
 
 }

--- a/src/Plugin/Field/FieldFormatter/MediaResponsiveImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MediaResponsiveImageFormatter.php
@@ -40,7 +40,7 @@ class MediaResponsiveImageFormatter extends MediaImageFormatterBase {
   /**
    * {@inheritdoc}
    */
-  public function preRender($element) {
+  public static function preRender($element) {
     $source_field = self::getSourceField($element['#media']);
     // If the source field is not an image field, don't modify anything.
     if (empty($element[$source_field]['#field_type']) || $element[$source_field]['#field_type'] != 'image') {

--- a/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
@@ -3,9 +3,7 @@
 namespace Drupal\stanford_media\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\media\MediaInterface;
 
 /**
  * Plugin implementation of the 'multi media' formatter.

--- a/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
@@ -174,13 +174,14 @@ class MultiMediaFormatter extends MediaFormatterBase {
 
     // Loop through each media type and try to find a render method.
     foreach ($elements as &$element) {
+      /** @var \Drupal\media\MediaInterface $media_item */
       $media_item = $element['#media'];
 
-      $bundle = $media_item->bundle();
-      $method_name = 'view' . ucfirst(strtolower($bundle)) . "Element";
+      $source_id  = $media_item->getSource()->getPluginId();
+      $method_name = 'view' . ucfirst(strtolower($source_id)) . "Element";
 
-      $vm_setting = $bundle . "_formatter_view_mode";
-      $view_mode = (!empty($this->getSetting($bundle)[$vm_setting])) ? $this->getSetting($bundle)[$vm_setting] : 'default';
+      $vm_setting = $source_id . "_formatter_view_mode";
+      $view_mode = (!empty($this->getSetting($source_id)[$vm_setting])) ? $this->getSetting($source_id)[$vm_setting] : 'default';
       $element['#view_mode'] = $view_mode;
 
       if (method_exists($this, $method_name)) {

--- a/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\stanford_media\Plugin\Field\FieldFormatter;
 
-use Drupal\media\Entity\Media;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\media\MediaInterface;
 
 /**
  * Plugin implementation of the 'multi media' formatter.
@@ -181,7 +181,14 @@ class MultiMediaFormatter extends MediaFormatterBase {
     // Loop through each media type and try to find a render method.
     foreach ($items as $item) {
       $media_id = $item->getValue()['target_id'];
-      $media_item = Media::load($media_id);
+
+      /** @var \Drupal\media\MediaInterface $media_item */
+      $media_item = $this->entityTypeManager->getStorage('media')->load($media_id);
+      // The media item was probably deleted, continue on to the others.
+      if (!$media_item) {
+        continue;
+      }
+
       $bundle = $media_item->bundle();
       $method_name = 'view' . ucfirst(strtolower($bundle)) . "Element";
 
@@ -205,7 +212,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
    *   A list of EntityReferenceItems.
    * @param \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $item
    *   A single item from the FieldItemList object.
-   * @param \Drupal\media\Entity\Media $media
+   * @param \Drupal\media\MediaInterface $media
    *   An instantiated Media Object.
    * @param string $langcode
    *   A langcode string key. eg: en.
@@ -215,7 +222,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
    * @return array
    *   A render array.
    */
-  private function viewImageElement(FieldItemListInterface $items, EntityReferenceItem $item, Media $media, $langcode, $view_mode = "default") {
+  private function viewImageElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
     $op = $this->getSetting('image')['image_formatter'] ?: '';
     $settings = ['link' => FALSE];
     $settings['image_style'] = ($op == "image_style") ? $this->settings['image']['image_formatter_image_style'] : $this->settings['image']['image_formatter_responsive_image_style'];
@@ -248,7 +255,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
    *   A list of EntityReferenceItems.
    * @param \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $item
    *   A single item from the FieldItemList object.
-   * @param \Drupal\media\Entity\Media $media
+   * @param \Drupal\media\MediaInterface $media
    *   An instantiated Media Object.
    * @param string $langcode
    *   A langcode string key. eg: en.
@@ -263,7 +270,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
    *   and including guzzle. A functional test has already been written for
    *   oembed and can be extended. The functional test covers this function.
    */
-  private function viewVideoElement(FieldItemListInterface $items, EntityReferenceItem $item, Media $media, $langcode, $view_mode = "default") {
+  private function viewVideoElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
     return [$this->entityTypeManager->getViewBuilder('media')->view($media, $view_mode)];
   }
 
@@ -274,7 +281,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
    *   A list of EntityReferenceItems.
    * @param \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $item
    *   A single item from the FieldItemList object.
-   * @param \Drupal\media\Entity\Media $media
+   * @param \Drupal\media\MediaInterface $media
    *   An instantiated Media Object.
    * @param string $langcode
    *   A langcode string key. eg: en.
@@ -284,7 +291,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
    * @return array
    *   A render array for a view mode.
    */
-  private function viewDefaultElement(FieldItemListInterface $items, EntityReferenceItem $item, Media $media, $langcode, $view_mode = "default") {
+  private function viewDefaultElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
     return [$this->entityTypeManager->getViewBuilder('media')->view($media, $view_mode)];
   }
 

--- a/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
@@ -177,7 +177,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
       /** @var \Drupal\media\MediaInterface $media_item */
       $media_item = $element['#media'];
 
-      $source_id  = $media_item->getSource()->getPluginId();
+      $source_id = $media_item->getSource()->getPluginId();
       $method_name = 'view' . ucfirst(strtolower($source_id)) . "Element";
 
       $vm_setting = $source_id . "_formatter_view_mode";

--- a/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
@@ -222,7 +222,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
    * @return array
    *   A render array.
    */
-  private function viewImageElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
+  protected function viewImageElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
     $op = $this->getSetting('image')['image_formatter'] ?: '';
     $settings = ['link' => FALSE];
     $settings['image_style'] = ($op == "image_style") ? $this->settings['image']['image_formatter_image_style'] : $this->settings['image']['image_formatter_responsive_image_style'];
@@ -270,7 +270,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
    *   and including guzzle. A functional test has already been written for
    *   oembed and can be extended. The functional test covers this function.
    */
-  private function viewVideoElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
+  protected function viewVideoElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
     return [$this->entityTypeManager->getViewBuilder('media')->view($media, $view_mode)];
   }
 
@@ -291,7 +291,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
    * @return array
    *   A render array for a view mode.
    */
-  private function viewDefaultElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
+  protected function viewDefaultElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
     return [$this->entityTypeManager->getViewBuilder('media')->view($media, $view_mode)];
   }
 

--- a/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
@@ -133,7 +133,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
       '#default_value' => $this->getSetting('image')['image_formatter_responsive_image_style'],
       '#states' => [
         'visible' => [
-          ':input[id="image_formatter"]' => ['value' => 'responsive_image'],
+          ':input[id="image_formatter"]' => ['value' => 'responsive_image_style'],
         ],
       ],
     ];
@@ -142,12 +142,8 @@ class MultiMediaFormatter extends MediaFormatterBase {
       '#type' => 'select',
       '#options' => $this->getEntityDisplayModes(),
       '#title' => $this->t('Image View Mode'),
+      '#description' => $this->t('Choose the view mode that the image styles will apply onto (if applicable).'),
       '#default_value' => $this->getSetting('image')['image_formatter_view_mode'] ?: '',
-      '#states' => [
-        'visible' => [
-          ':input[id="image_formatter"]' => ['value' => 'entity'],
-        ],
-      ],
     ];
 
     $elements['video']['video_formatter'] = [
@@ -176,29 +172,21 @@ class MultiMediaFormatter extends MediaFormatterBase {
    * {@inheritdoc}
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
-    $elements = [];
+    $elements = parent::viewElements($items, $langcode);
 
     // Loop through each media type and try to find a render method.
-    foreach ($items as $item) {
-      $media_id = $item->getValue()['target_id'];
-
-      /** @var \Drupal\media\MediaInterface $media_item */
-      $media_item = $this->entityTypeManager->getStorage('media')->load($media_id);
-      // The media item was probably deleted, continue on to the others.
-      if (!$media_item) {
-        continue;
-      }
+    foreach ($elements as &$element) {
+      $media_item = $element['#media'];
 
       $bundle = $media_item->bundle();
       $method_name = 'view' . ucfirst(strtolower($bundle)) . "Element";
 
+      $vm_setting = $bundle . "_formatter_view_mode";
+      $view_mode = (!empty($this->getSetting($bundle)[$vm_setting])) ? $this->getSetting($bundle)[$vm_setting] : 'default';
+      $element['#view_mode'] = $view_mode;
+
       if (method_exists($this, $method_name)) {
-        $vm_setting = $bundle . "_formatter_view_mode";
-        $view_mode = (!empty($this->getSetting($bundle)[$vm_setting])) ? $this->getSetting($bundle)[$vm_setting] : 'default';
-        $elements += $this->{$method_name}($items, $item, $media_item, $langcode, $view_mode);
-      }
-      else {
-        $elements += $this->viewDefaultElement($items, $item, $media_item, $langcode, $this->getSetting('view_mode'));
+        $this->{$method_name}($items, $element);
       }
     }
 
@@ -210,89 +198,23 @@ class MultiMediaFormatter extends MediaFormatterBase {
    *
    * @param \Drupal\Core\Field\FieldItemListInterface $items
    *   A list of EntityReferenceItems.
-   * @param \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $item
-   *   A single item from the FieldItemList object.
-   * @param \Drupal\media\MediaInterface $media
-   *   An instantiated Media Object.
-   * @param string $langcode
-   *   A langcode string key. eg: en.
-   * @param string $view_mode
-   *   The view mode machine name.
-   *
-   * @return array
-   *   A render array.
+   * @param array $element
+   *   A single render element.
    */
-  protected function viewImageElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
+  protected function viewImageElement(FieldItemListInterface $items, array &$element) {
     $op = $this->getSetting('image')['image_formatter'] ?: '';
-    $settings = ['link' => FALSE];
-    $settings['image_style'] = ($op == "image_style") ? $this->settings['image']['image_formatter_image_style'] : $this->settings['image']['image_formatter_responsive_image_style'];
-    $formatter = NULL;
-
-    // Static Image Style Render.
-    if ($op == "image_style") {
-      $formatter = new MediaImageFormatter($this->pluginId, $this->pluginDefinition, $this->fieldDefinition, $settings, $this->label, $view_mode, $this->thirdPartySettings, $this->loggerFactory, $this->entityTypeManager, $this->entityDisplayRepository);
+    if (!in_array($op, ['image_style', 'responsive_image_style'])) {
+      return;
     }
 
-    // Responsive Image Style Render.
-    if ($op == "responsive_image_style") {
-      $formatter = new MediaResponsiveImageFormatter($this->pluginId, $this->pluginDefinition, $this->fieldDefinition, $settings, $this->label, $view_mode, $this->thirdPartySettings, $this->loggerFactory, $this->entityTypeManager, $this->entityDisplayRepository);
+    $element['#stanford_media_image_style'] = ($op == "image_style") ? $this->settings['image']['image_formatter_image_style'] : $this->settings['image']['image_formatter_responsive_image_style'];
+
+    if ($op == 'image_style') {
+      $element['#pre_render'][] = [MediaImageFormatter::class, 'preRender'];
+      return;
     }
 
-    // Found one.
-    if ($formatter) {
-      return $formatter->viewElements($items, $langcode);
-    }
-
-    // Entity Render View Mode.
-    $view_mode = $this->settings['image']['image_formatter_view_mode'] ?: $view_mode;
-    return [$this->entityTypeManager->getViewBuilder('media')->view($media, $view_mode)];
-  }
-
-  /**
-   * Use view modes to generate a render array.
-   *
-   * @param \Drupal\Core\Field\FieldItemListInterface $items
-   *   A list of EntityReferenceItems.
-   * @param \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $item
-   *   A single item from the FieldItemList object.
-   * @param \Drupal\media\MediaInterface $media
-   *   An instantiated Media Object.
-   * @param string $langcode
-   *   A langcode string key. eg: en.
-   * @param string $view_mode
-   *   The view mode machine name.
-   *
-   * @return array
-   *   A render array for a view mode.
-   *
-   * @codeCoverageIgnore
-   *   Ignore this because in order to test it you have to mock everything up to
-   *   and including guzzle. A functional test has already been written for
-   *   oembed and can be extended. The functional test covers this function.
-   */
-  protected function viewVideoElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
-    return [$this->entityTypeManager->getViewBuilder('media')->view($media, $view_mode)];
-  }
-
-  /**
-   * Use view modes to generate a render array.
-   *
-   * @param \Drupal\Core\Field\FieldItemListInterface $items
-   *   A list of EntityReferenceItems.
-   * @param \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $item
-   *   A single item from the FieldItemList object.
-   * @param \Drupal\media\MediaInterface $media
-   *   An instantiated Media Object.
-   * @param string $langcode
-   *   A langcode string key. eg: en.
-   * @param string $view_mode
-   *   The view mode machine name.
-   *
-   * @return array
-   *   A render array for a view mode.
-   */
-  protected function viewDefaultElement(FieldItemListInterface $items, EntityReferenceItem $item, MediaInterface $media, $langcode, $view_mode = "default") {
-    return [$this->entityTypeManager->getViewBuilder('media')->view($media, $view_mode)];
+    $element['#pre_render'][] = [MediaResponsiveImageFormatter::class, 'preRender'];
   }
 
   /**

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/MultiMediaFormatterTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/MultiMediaFormatterTest.php
@@ -38,7 +38,7 @@ class MultiMediaFormatterTest extends KernelTestBase {
     'media',
     'entity_reference',
     'breakpoint',
-    'responsive_image'
+    'responsive_image',
   ];
 
   /**
@@ -285,7 +285,7 @@ class MultiMediaFormatterTest extends KernelTestBase {
         ],
         'other' => [
           'view_mode' => 'default',
-        ]
+        ],
       ],
     ];
   }
@@ -330,6 +330,14 @@ class MultiMediaFormatterTest extends KernelTestBase {
 
     $node = $this->getANode();
     $rendered_node = $this->getRenderedNode($node);
+    preg_match_all('/<img.*src=".*\/logo.png.*\/>/s', $rendered_node, $preg_match);
+    $this->assertNotEmpty($preg_match[0]);
+
+    // Now delete the media and make sure it doesn't break.
+    $this->mediaEntities['image']->delete();
+    $node = Node::load($node->id());
+    $rendered_node = $this->getRenderedNode($node);
+
     preg_match_all('/<img.*src=".*\/logo.png.*\/>/s', $rendered_node, $preg_match);
     $this->assertNotEmpty($preg_match[0]);
   }

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/MultiMediaFormatterTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/MultiMediaFormatterTest.php
@@ -339,7 +339,7 @@ class MultiMediaFormatterTest extends KernelTestBase {
     $rendered_node = $this->getRenderedNode($node);
 
     preg_match_all('/<img.*src=".*\/logo.png.*\/>/s', $rendered_node, $preg_match);
-    $this->assertNotEmpty($preg_match[0]);
+    $this->assertEmpty($preg_match[0]);
   }
 
   /**

--- a/tests/src/Unit/Plugin/Field/FieldFormatter/MediaImageFormatterTest.php
+++ b/tests/src/Unit/Plugin/Field/FieldFormatter/MediaImageFormatterTest.php
@@ -59,6 +59,7 @@ class MediaImageFormatterTest extends FieldFormatterTestBase {
       '#media' => $this->getMockMediaEntity(),
       '#stanford_media_image_style' => 'style_foo',
       'field_foo' => [
+        '#field_type' => 'image',
         0 => [],
       ],
     ];
@@ -75,6 +76,22 @@ class MediaImageFormatterTest extends FieldFormatterTestBase {
     $this->assertArrayHasKey('#url', $element['field_foo'][0]);
     $this->assertEquals('http://foo.bar', $element['field_foo'][0]['#url']);
     $this->assertEquals('Foo Bar', $element['field_foo'][0]['#attributes']['title']);
+  }
+
+  /**
+   * When the source field is not an image, the preRender should do nothing.
+   */
+  public function testPreRenderNonImage() {
+    $before = [
+      '#media' => $this->getMockMediaEntity(),
+      '#stanford_media_image_style' => 'style_foo',
+      'field_foo' => [
+        '#field_type' => 'video',
+        0 => [],
+      ],
+    ];
+    $after = $this->plugin->preRender($before);
+    $this->assertArrayEquals($before, $after);
   }
 
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed formatter when the media item has been deleted. https://github.com/SU-SWS/stanford_media/pull/41
- Fixed image formatter when a non-image media item is used.

# Need Review By (Date)
- Next week

# Urgency
- Medium

# Steps to Test
1. Checkout this branch
1. clear caches
1. create a basic page with a "Media with Caption" paragraph
1. validate it looks good
1. delete the media entity via `/admin/content/media`
1. go back to the page you created
1. validate the page still loads even if theres no image.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

