### PR TITLE
D8 core 1706

### DIFF
--- a/.github/auto-label.json
+++ b/.github/auto-label.json
@@ -3,6 +3,7 @@
     "patch": ["*.info.yml"],
     "frontend": ["*.js", "*.scss", "*.css", "*.twig", ".theme"],
     "backend": ["*.php", "*.module"],
-    "ci": [".circleci", "blt", ".github"]
+    "ci": [".circleci", "blt", ".github"],
+    "tests": ["tests"]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
                 "https://www.drupal.org/project/drupal/issues/3064751": "https://www.drupal.org/files/issues/2019-07-02/3064751-5.patch"
             },
             "drupal/focal_point": {
-                "https://www.drupal.org/project/focal_point/issues/3094478": "https://www.drupal.org/files/issues/2019-12-11/focal_point-compatibility-with-media-libary-3094478-2.patch",
+                "https://www.drupal.org/project/focal_point/issues/3094478": "https://www.drupal.org/files/issues/2020-01-09/3094478-10.patch",
                 "https://www.drupal.org/project/focal_point/issues/3098235": "https://www.drupal.org/files/issues/2020-03-23/focal_point-3098235-13.patch"
             }
         }

--- a/src/Form/MediaLibraryFileUploadForm.php
+++ b/src/Form/MediaLibraryFileUploadForm.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\stanford_media\Form;
 
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\File\FileSystemInterface;

--- a/src/Form/MediaLibraryFileUploadForm.php
+++ b/src/Form/MediaLibraryFileUploadForm.php
@@ -137,18 +137,6 @@ class MediaLibraryFileUploadForm extends FileUploadForm {
   }
 
   /**
-   * {@inheritDoc}
-   */
-  public function updateFormCallback(array &$form, FormStateInterface $form_state) {
-    if (empty($form_state->getValue(['dropzone', 'uploaded_files']))) {
-      $response = new AjaxResponse();
-      $response->addCommand(new ReplaceCommand('#media-library-add-form-wrapper', $form));
-      return $response;
-    }
-    return parent::updateFormCallback($form, $form_state);
-  }
-
-  /**
    * Submit handler for the upload button, below the dropzone area..
    *
    * @param array $form

--- a/tests/src/Kernel/Form/MediaLibraryFileUploadFormTest.php
+++ b/tests/src/Kernel/Form/MediaLibraryFileUploadFormTest.php
@@ -80,11 +80,6 @@ class MediaLibraryFileUploadFormTest extends StanfordMediaFormTestBase {
 
     /** @var \Drupal\stanford_media\Form\MediaLibraryFileUploadForm $form_object */
     $form_object = $form_state->getFormObject();
-    $response_commands = $form_object->updateFormCallback($form, $form_state)
-      ->getCommands();
-    $this->assertCount(1, $response_commands);
-    $this->assertEquals('insert', $response_commands[0]['command']);
-    $this->assertEquals('#media-library-add-form-wrapper', $response_commands[0]['selector']);
 
     $form_state->setValue([
       'dropzone',
@@ -94,11 +89,6 @@ class MediaLibraryFileUploadFormTest extends StanfordMediaFormTestBase {
       '#parents' => [],
       '#ajax' => ['wrapper' => 'foo'],
     ]);
-    $response_commands = $form_object->updateFormCallback($form, $form_state)
-      ->getCommands();
-    $this->assertCount(2, $response_commands);
-    $this->assertEquals('#foo', $response_commands[0]['selector']);
-    $this->assertEquals('invoke', $response_commands[1]['command']);
 
     $this->assertCount(0, File::loadMultiple());
     $form_object->uploadDropzoneSubmit($form, $form_state);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed weirdness when a user cancels/deletes a file after adding it. The user is now brought back to the original form just like they didn't upload anything.
- updated focal_point patch: see https://github.com/SU-SWS/acsf-cardinalsites/pull/136

# Need Review By (Date)
- 4/8

# Urgency
- medium-high

# Steps to Test
1. checkout this branch
1. Go to a basic page
1. go to any field that allows images
1. upload an image
1. when you're asked for the alt text, click the X to delete the media item
1. validate you are brought back and can continue like normal.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
