### PR TITLE
D8CORE-1223 Added caption field to the image modal in wysiwyg

### DIFF
--- a/src/Plugin/MediaEmbedDialog/Image.php
+++ b/src/Plugin/MediaEmbedDialog/Image.php
@@ -83,6 +83,7 @@ class Image extends MediaEmbedDialogBase {
       $values['attributes']['data-caption-hash'] = substr(md5($text), 0, 5);
     }
   }
+
   /**
    * {@inheritdoc}
    */

--- a/src/Plugin/MediaEmbedDialog/Image.php
+++ b/src/Plugin/MediaEmbedDialog/Image.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\stanford_media\Plugin\MediaEmbedDialog;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\media\MediaInterface;
+use Drupal\stanford_media\Plugin\MediaEmbedDialogBase;
+use Drupal\media\Plugin\media\Source\Image as ImageSource;
+
+/**
+ * Changes embedded Image media form.
+ *
+ * @MediaEmbedDialog(
+ *   id = "image"
+ * )
+ */
+class Image extends MediaEmbedDialogBase {
+
+  /**
+   * List of tags that are allowed in the caption field.
+   *
+   * This list is pulled from Drupal core media ckeditor plugin.js.
+   *
+   * @var string
+   */
+  const CAPTION_ALLOWED_TAGS = '<a> <em> <strong> <cite> <code> <br>';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultInput() {
+    return ['data-caption' => NULL];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isApplicable() {
+    if ($this->entity instanceof MediaInterface) {
+      return $this->entity->getSource() instanceof ImageSource;
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterDialogForm(array &$form, FormStateInterface $form_state) {
+    parent::alterDialogForm($form, $form_state);
+    $user_input = $this->getUserInput($form_state);
+
+    if (!isset($form['caption'])) {
+      return;
+    }
+
+    // Allow a user to edit the caption text in the modal.
+    $form['caption_text'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Caption Text'),
+      '#description' => $this->t('Enter some contextual information about the image. Allowed tags are: @tags', ['@tags' => self::CAPTION_ALLOWED_TAGS]),
+      '#default_value' => trim($user_input['data-caption']) ?? '',
+      '#states' => [
+        'visible' => [
+          ':input[name="hasCaption"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterDialogValues(array &$values, array $form, FormStateInterface $form_state) {
+    if ($form_state->getValue('hasCaption')) {
+      $text = $form_state->getValue('caption_text');
+      $text = strip_tags($text, self::CAPTION_ALLOWED_TAGS);
+
+      $values['attributes']['data-caption'] = $text;
+      // We need to set a dummy attribute because the media's ckeditor plugin
+      // javascript hashes all the attributes except `data-caption` and doing
+      // this will allow the media preview to be re-generated when the caption
+      // changes in the modal.
+      $values['attributes']['data-caption-hash'] = substr(md5($text), 0, 5);
+    }
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function embedAlter(array &$build, MediaInterface $entity) {
+    unset($build['#attributes']['data-caption-hash']);
+  }
+
+}

--- a/tests/src/Unit/Plugin/MediaEmbedDialog/ImageTest.php
+++ b/tests/src/Unit/Plugin/MediaEmbedDialog/ImageTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\Tests\stanford_media\Unit\Plugin\MediaEmbedDialog;
+
+use Drupal\Core\Form\FormState;
+use Drupal\stanford_media\Plugin\MediaEmbedDialog\Image;
+use Drupal\media\Plugin\media\Source\Image as ImageSource;
+
+/**
+ * Class Image.
+ *
+ * @group stanford_media
+ * @coversDefaultClass \Drupal\stanford_media\Plugin\MediaEmbedDialog\Image
+ */
+class ImageTest extends MediaEmbedDialogTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->mediaBundle = 'image';
+    $this->mediaSource = $this->createMock(ImageSource::class);
+  }
+
+  /**
+   * Test the plugin is applicable.
+   */
+  public function testPluginApplication() {
+    $plugin = Image::create($this->container, ['entity' => new \stdClass()], '', []);
+    $this->assertFalse($plugin->isApplicable());
+
+    $plugin = Image::create($this->container, ['entity' => $this->mediaEntity], '', []);
+    $this->assertTrue($plugin->isApplicable());
+
+    $form = [];
+    $form_state = new FormState();
+    $form_state->clearErrors();
+    $this->assertNull($plugin->validateDialogForm($form, $form_state));
+    $this->assertFalse($form_state::hasAnyErrors());
+  }
+
+  /**
+   * Dialog form should alter correctly.
+   */
+  public function testDialogAlter() {
+    $plugin = Image::create($this->container, ['entity' => $this->mediaEntity], '', []);
+
+    $form = ['attributes' => ['data-caption' => ['#type' => 'textfield']]];
+    $form_state = new FormState();
+    $user_input = ['editor_object' => ['attributes' => ['data-caption' => 'foo bar']]];
+    $form_state->setUserInput($user_input);
+    $plugin->alterDialogForm($form, $form_state);
+
+    $this->assertArrayNotHasKey('caption_text', $form);
+
+    $form['caption'] = [];
+    $plugin->alterDialogForm($form, $form_state);
+    $this->assertArrayHasKey('caption_text', $form);
+    $this->assertEquals('foo bar', $form['caption_text']['#default_value']);
+  }
+
+  /**
+   * Alter dialog values will strip html tags except some.
+   */
+  public function testAlterDialogValues() {
+    $form = [];
+    $plugin = Image::create($this->container, ['entity' => $this->mediaEntity], '', []);
+    $values = [];
+    $form_state = new FormState();
+    $form_state->setValues(['hasCaption' => 1, 'caption_text' => '<div>Foo <a href="/here">Bar</a> Baz</div>']);
+    $plugin->alterDialogValues($values, $form, $form_state);
+
+    $this->assertArrayEquals([
+      'attributes' => [
+        'data-caption' => 'Foo <a href="/here">Bar</a> Baz',
+        'data-caption-hash' => 'badc6',
+      ],
+    ], $values);
+  }
+
+  /**
+   * PreRender should set the field value.
+   */
+  public function testPreRender() {
+    $plugin = Image::create($this->container, ['entity' => $this->mediaEntity], '', []);
+    $build = [
+      '#media' => $this->mediaEntity,
+      '#attributes' => ['data-caption-hash' => 'foo bar'],
+    ];
+    $plugin->embedAlter($build, $this->mediaEntity);
+    $this->assertArrayNotHasKey('data-caption-hash', $build['#attributes']);
+  }
+
+}

--- a/tests/src/Unit/Plugin/MediaEmbedDialog/MediaEmbedDialogTestBase.php
+++ b/tests/src/Unit/Plugin/MediaEmbedDialog/MediaEmbedDialogTestBase.php
@@ -40,6 +40,8 @@ abstract class MediaEmbedDialogTestBase extends UnitTestCase {
    */
   protected $mediaBundle;
 
+  protected $mediaSource;
+
   /**
    * {@inheritDoc}
    */
@@ -69,8 +71,8 @@ abstract class MediaEmbedDialogTestBase extends UnitTestCase {
     $this->container->set('path.validator', $this->createMock(PathValidatorInterface::class));
     \Drupal::setContainer($this->container);
 
-    $media_source = $this->createMock(MediaSourceInterface::class);
-    $media_source->method('getConfiguration')
+    $this->mediaSource = $this->createMock(MediaSourceInterface::class);
+    $this->mediaSource->method('getConfiguration')
       ->willReturn(['source_field' => 'field_foo']);
 
     $field_list = $this->createMock(FieldItemListInterface::class);
@@ -78,20 +80,9 @@ abstract class MediaEmbedDialogTestBase extends UnitTestCase {
       ->will($this->returnCallback([$this, 'fieldGetStringCallback']));
 
     $this->mediaEntity = $this->createMock(MediaInterface::class);
-    $this->mediaEntity->method('bundle')
-      ->will($this->returnCallback([$this, 'mediaBundleCallback']));
-    $this->mediaEntity->method('getSource')->willReturn($media_source);
+    $this->mediaEntity->method('bundle')->willReturnReference($this->mediaBundle);
+    $this->mediaEntity->method('getSource')->willReturnReference($this->mediaSource);
     $this->mediaEntity->method('get')->willReturn($field_list);
-  }
-
-  /**
-   * Media bundle callback.
-   *
-   * @return string
-   *   What media bundle the mock entity is.
-   */
-  public function mediaBundleCallback() {
-    return $this->mediaBundle;
   }
 
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- added caption to the modal of the image in a wysywig so that a user can set the caption text as soon as they check the box to enable a caption

# Need Review By (Date)
- 4/8

# Urgency
- medium

# Steps to Test
1. Checkout this branch
1. clear caches
1. add an image to any wysywig
1. click the "Edit Media" button
1. check the box "Caption"
1. Enter text in the "Caption Text" box
1. Click "Save"
1. validate the caption text on the image in the wysiwyg is set to what you entered.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
