### PR TITLE
Disable cache for image field formatters.

### DIFF
--- a/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
@@ -50,6 +50,10 @@ class MediaImageFormatter extends MediaImageFormatterBase {
       }
 
     }
+    // Disable cache for this field formatter.
+    // https://www.drupal.org/project/drupal/issues/2099131.
+    // https://www.drupal.org/node/2151609.
+    $element['#cache'] = FALSE;
     return $element;
   }
 

--- a/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
@@ -43,17 +43,15 @@ class MediaImageFormatter extends MediaImageFormatterBase {
       $item = &$element[$source_field][$delta];
       $item['#theme'] = 'image_formatter';
       $item['#image_style'] = $element['#stanford_media_image_style'];
-
+      // Disable cache for this field formatter.
+      $item['#cache']['keys'][] = $element['#stanford_media_image_style'];
+      
       if (isset($element['#stanford_media_url'])) {
         $item['#url'] = $element['#stanford_media_url'];
         $item['#attributes']['title'] = $element['#stanford_media_url_title'];
       }
 
     }
-    // Disable cache for this field formatter.
-    // https://www.drupal.org/project/drupal/issues/2099131.
-    // https://www.drupal.org/node/2151609.
-    $element['#cache'] = FALSE;
     return $element;
   }
 

--- a/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MediaImageFormatter.php
@@ -43,15 +43,13 @@ class MediaImageFormatter extends MediaImageFormatterBase {
       $item = &$element[$source_field][$delta];
       $item['#theme'] = 'image_formatter';
       $item['#image_style'] = $element['#stanford_media_image_style'];
-      // Disable cache for this field formatter.
-      $item['#cache']['keys'][] = $element['#stanford_media_image_style'];
-      
+
       if (isset($element['#stanford_media_url'])) {
         $item['#url'] = $element['#stanford_media_url'];
         $item['#attributes']['title'] = $element['#stanford_media_url_title'];
       }
-
     }
+
     return $element;
   }
 

--- a/src/Plugin/Field/FieldFormatter/MediaImageFormatterBase.php
+++ b/src/Plugin/Field/FieldFormatter/MediaImageFormatterBase.php
@@ -117,7 +117,6 @@ abstract class MediaImageFormatterBase extends MediaFormatterBase implements Tru
     }
 
     $elements['#cache']['keys'][] = $style;
-    $elements['#pre_rendered'] = TRUE;
     return $elements;
   }
 

--- a/src/Plugin/Field/FieldFormatter/MediaImageFormatterBase.php
+++ b/src/Plugin/Field/FieldFormatter/MediaImageFormatterBase.php
@@ -115,6 +115,9 @@ abstract class MediaImageFormatterBase extends MediaFormatterBase implements Tru
         $element['#stanford_media_url_title'] = $parent->label();
       }
     }
+
+    $elements['#cache']['keys'][] = $style;
+    $elements['#pre_rendered'] = TRUE;
     return $elements;
   }
 

--- a/src/Plugin/Field/FieldFormatter/MediaResponsiveImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MediaResponsiveImageFormatter.php
@@ -62,7 +62,7 @@ class MediaResponsiveImageFormatter extends MediaImageFormatterBase {
     // Disable cache for this field formatter.
     // https://www.drupal.org/project/drupal/issues/2099131.
     // https://www.drupal.org/node/2151609.
-    $element['cache'] = FALSE;
+    $element['#cache']['keys'][] = $element['#stanford_media_image_style'];
     return $element;
   }
 

--- a/src/Plugin/Field/FieldFormatter/MediaResponsiveImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MediaResponsiveImageFormatter.php
@@ -59,10 +59,6 @@ class MediaResponsiveImageFormatter extends MediaImageFormatterBase {
       }
     }
 
-    // Disable cache for this field formatter.
-    // https://www.drupal.org/project/drupal/issues/2099131.
-    // https://www.drupal.org/node/2151609.
-    $element['#cache']['keys'][] = $element['#stanford_media_image_style'];
     return $element;
   }
 

--- a/src/Plugin/Field/FieldFormatter/MediaResponsiveImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MediaResponsiveImageFormatter.php
@@ -58,6 +58,11 @@ class MediaResponsiveImageFormatter extends MediaImageFormatterBase {
         $item['#attributes']['title'] = $element['#stanford_media_url_title'];
       }
     }
+
+    // Disable cache for this field formatter.
+    // https://www.drupal.org/project/drupal/issues/2099131.
+    // https://www.drupal.org/node/2151609.
+    $element['cache'] = FALSE;
     return $element;
   }
 

--- a/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/MultiMediaFormatter.php
@@ -207,6 +207,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
     }
 
     $element['#stanford_media_image_style'] = ($op == "image_style") ? $this->settings['image']['image_formatter_image_style'] : $this->settings['image']['image_formatter_responsive_image_style'];
+    $element['#cache']['keys'][] = $element['#stanford_media_image_style'];
 
     if ($op == 'image_style') {
       $element['#pre_render'][] = [MediaImageFormatter::class, 'preRender'];
@@ -214,6 +215,7 @@ class MultiMediaFormatter extends MediaFormatterBase {
     }
 
     $element['#pre_render'][] = [MediaResponsiveImageFormatter::class, 'preRender'];
+
   }
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Disables cache for image field formatters.
- https://www.drupal.org/project/drupal/issues/2099131
- https://www.drupal.org/node/2151609

- Should look into placeholders and `#lazy_builder` https://www.drupal.org/node/2498803

# Needed By (Date)
- Next release

# Urgency
- Med-low

# Steps to Test

1. Create a page and render the same image with multiple view mode options via block, view, or something else.
2. Clear render cache and view page. 
3. All the items should be the same image format
4. Check out this branch
5. Clear render cache
6. Reload page and each image is its own image format.

