### PR TITLE
D8CORE-2514: Added div to the list of allowed tags in unstructured embeds

### DIFF
--- a/src/Plugin/Field/FieldFormatter/EmbeddableFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EmbeddableFormatter.php
@@ -152,6 +152,7 @@ class EmbeddableFormatter extends OEmbedFormatter {
             'source',
             'embed',
             'script',
+            'div',
           ],
           '#prefix' => '<div class="embeddable-content">',
           '#suffix' => '</div>',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Some flavors of unstructured embeds require `div` elements, which were being stripped out. Added `div` to the list of allowed tags in the field formatter.

# Needed By (Date)
- 10/1/2020

# Urgency
- 5 out of 10

# Steps to Test

1. Pull this branch into your stack.
2. Edit an existing piece of content
3. Add an unstructured embeddable that includes a div.

Here is some convenient sample code:
```
<script type='text/javascript' src='https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js'></script>
<div class='altmetric-embed' data-badge-type='donut' data-doi="10.1038/nature.2012.9872"></div>
```
4. Save the updated content.
5. Verify the div shows up correctly in the spot where the embeddable should be.
![image](https://user-images.githubusercontent.com/1263892/94613140-5836c600-0261-11eb-9238-6bc4675260a4.png)

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
