### PR TITLE
D8CORE-2267 Removed caption checkbox from file media

### DIFF
--- a/src/Plugin/MediaEmbedDialog/File.php
+++ b/src/Plugin/MediaEmbedDialog/File.php
@@ -39,7 +39,7 @@ class File extends MediaEmbedDialogBase {
   public function alterDialogForm(array &$form, FormStateInterface $form_state) {
     parent::alterDialogForm($form, $form_state);
     $user_input = $this->getUserInput($form_state);
-
+    unset($form['caption']);
     $form['description'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Description'),


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove the ability to add a caption to file media type.

# Need Review By (Date)
- 12/3

# Urgency
- low

# Steps to Test
1. checkout this branch
1. create a page and embed a pdf or doc file
1. in the edit media dialog, validate you don't have the ability to add a caption to the file.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
