### PR TITLE
Remove the filter caption template in favor of preprocess hook'

### DIFF
--- a/stanford_media.module
+++ b/stanford_media.module
@@ -116,3 +116,13 @@ function stanford_media_preprocess_media(&$variables) {
     $variables['content'][$source_field][0]['#description'] = $variables['name'];
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function stanford_media_preprocess_filter_caption(&$variables){
+  if (!isset($variables['classes'])) {
+    $variables['classes'] = '';
+  }
+  $variables['classes'] = trim($variables['classes'] . ' caption');
+}

--- a/stanford_media.module
+++ b/stanford_media.module
@@ -120,7 +120,7 @@ function stanford_media_preprocess_media(&$variables) {
 /**
  * Implements hook_preprocess_HOOK().
  */
-function stanford_media_preprocess_filter_caption(&$variables){
+function stanford_media_preprocess_filter_caption(&$variables) {
   if (!isset($variables['classes'])) {
     $variables['classes'] = '';
   }

--- a/stanford_media.module
+++ b/stanford_media.module
@@ -37,7 +37,6 @@ function stanford_media_theme_registry_alter(&$theme_registry) {
   // Register the path to the template files.
   $path = drupal_get_path('module', 'stanford_media') . '/templates';
   $theme_registry['dropzonejs']['path'] = $path;
-  $theme_registry['filter_caption']['path'] = $path;
 }
 
 /**

--- a/templates/filter-caption.html.twig
+++ b/templates/filter-caption.html.twig
@@ -1,1 +1,0 @@
-{% extends '@classy/content-edit/filter-caption.html.twig' %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed the template that does nothing
- Since we have some styles for the `caption` class, we'll use a preprocess hook to add that. (for some stupid reason the template in core doesn't use the `attributes` variable.

# Need Review By (Date)
- :shrug: 

# Urgency
- medium

# Steps to Test
1. checkout this branch
1. clear cache
1. create an image in the wysiwyg with a caption
1. see it still looks as expected.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
