### PR TITLE
Change filter type to work with Drupal 9.3.0 and Ckeditor 5

### DIFF
--- a/src/Plugin/Filter/MediaEmbedMarkupFilter.php
+++ b/src/Plugin/Filter/MediaEmbedMarkupFilter.php
@@ -12,7 +12,7 @@ use Drupal\filter\FilterProcessResult;
  *   id = "stanford_media_embed_markup",
  *   title = @Translation("Stanford Media Embed Filter"),
  *   description = @Translation("This helps with core markup issues. This filter has to run after the Embed Media filter."),
- *   type = Drupal\filter\Plugin\FilterInterface::TYPE_MARKUP_LANGUAGE,
+ *   type = Drupal\filter\Plugin\FilterInterface::TYPE_TRANSFORM_REVERSIBLE
  * )
  */
 class MediaEmbedMarkupFilter extends FilterBase {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow enabling on CKEditor 5 in D9.3
- see: https://git.drupalcode.org/project/drupal/-/blob/9.3.x/core/modules/ckeditor5/src/Plugin/Validation/Constraint/FundamentalCompatibilityConstraintValidator.php#L88

# Need Review By (Date)
- :shrug: 

# Urgency
- very low

# Steps to Test
1. enable ckeditor5 module
2. attempt to enable the stanford media filter on a text format with ckeditor 5
3. see the error
4. checkout this branch
5. clear caches
6.  reattempt to enable the filter with ckeditor 5
7. see no error.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
