### PR TITLE
D8CORE-5241 Adjust image alt text description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "davidbarratt/custom-installer": "~1.0",
-        "drupal/core": "^8.8 || ^9.0",
+        "drupal/core": "^9.3",
         "drupal/dropzonejs": "^2.0@alpha",
         "drupal/entity_usage": "^2.0-beta3",
         "drupal/inline_entity_form": "^1.0@beta",

--- a/src/StanfordMedia.php
+++ b/src/StanfordMedia.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\stanford_media;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Security\TrustedCallbackInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+
+/**
+ * Class StanfordMedia.
+ */
+class StanfordMedia implements TrustedCallbackInterface {
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function trustedCallbacks() {
+    return ['imageWidgetProcess'];
+  }
+
+  /**
+   * Process callback for image widget fields.
+   *
+   * @param array $element
+   *   Field element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Current form state.
+   * @param array $form
+   *   Complete form.
+   *
+   * @return array
+   *   Modified field element.
+   */
+  public static function imageWidgetProcess(array $element, FormStateInterface $form_state, array $form) {
+    if (!empty($element['alt']['#description'])) {
+      $url = Url::fromUri('https://uit.stanford.edu/accessibility/concepts/images');
+      $link = Link::fromTextAndUrl($url->toString(), $url)->toString();
+      $element['alt']['#description'] = new TranslatableMarkup('Short description of the image used by screen readers and displayed when the image is not loaded. Leave blank if image is decorative. Learn more about alternative text: @link', ['@link' => $link]);
+    }
+    return $element;
+  }
+
+}

--- a/stanford_media.module
+++ b/stanford_media.module
@@ -93,8 +93,8 @@ function stanford_media_ckeditor_css_alter(array &$css, Editor $editor) {
   /** @var \Drupal\Core\Extension\ModuleExtensionList $extensions */
   $extensions = \Drupal::service('extension.list.module');
   // Add styles inside the ckeditor iframe.
-  $css[] = $extensions->getPathname('stanford_media') . '/dist/css/stanford_media.admin.css';
-  $css[] = $extensions->getPathname('stanford_media') . '/dist/css/stanford_media.css';
+  $css[] = $extensions->getPath('stanford_media') . '/dist/css/stanford_media.admin.css';
+  $css[] = $extensions->getPath('stanford_media') . '/dist/css/stanford_media.css';
 }
 
 /**
@@ -102,7 +102,7 @@ function stanford_media_ckeditor_css_alter(array &$css, Editor $editor) {
  */
 function stanford_media_theme_registry_alter(&$theme_registry) {
   // Register the path to the template files.
-  $path = \Drupal::service('extension.list.module')->getPathname('stanford_media') . '/templates';
+  $path = \Drupal::service('extension.list.module')->getPath('stanford_media') . '/templates';
   $theme_registry['dropzonejs']['path'] = $path;
 }
 

--- a/stanford_media.module
+++ b/stanford_media.module
@@ -65,6 +65,20 @@ function stanford_media_media_presave(MediaInterface $entity) {
 }
 
 /**
+ * Implements hook_field_widget_form_alter().
+ */
+function stanford_media_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+  /** @var \Drupal\Core\Field\FieldItemListInterface $items */
+  $items = $context['items'];
+  if ($items->getFieldDefinition()->getType() == 'image') {
+    $element['#process'][] = [
+      '\Drupal\stanford_media\StanfordMedia',
+      'imageWidgetProcess',
+    ];
+  }
+}
+
+/**
  * Implements hook_field_widget_WIDGET_TYPE_form_alter().
  */
 function stanford_media_field_widget_text_textarea_form_alter(&$element, FormStateInterface $form_state, $context) {
@@ -76,9 +90,11 @@ function stanford_media_field_widget_text_textarea_form_alter(&$element, FormSta
  * Implements hook_ckeditor_css_alter().
  */
 function stanford_media_ckeditor_css_alter(array &$css, Editor $editor) {
-  // Adds styles inside the ckeditor iframe.
-  $css[] = drupal_get_path('module', 'stanford_media') . '/dist/css/stanford_media.admin.css';
-  $css[] = drupal_get_path('module', 'stanford_media') . '/dist/css/stanford_media.css';
+  /** @var \Drupal\Core\Extension\ModuleExtensionList $extensions */
+  $extensions = \Drupal::service('extension.list.module');
+  // Add styles inside the ckeditor iframe.
+  $css[] = $extensions->getPathname('stanford_media') . '/dist/css/stanford_media.admin.css';
+  $css[] = $extensions->getPathname('stanford_media') . '/dist/css/stanford_media.css';
 }
 
 /**
@@ -86,7 +102,7 @@ function stanford_media_ckeditor_css_alter(array &$css, Editor $editor) {
  */
 function stanford_media_theme_registry_alter(&$theme_registry) {
   // Register the path to the template files.
-  $path = drupal_get_path('module', 'stanford_media') . '/templates';
+  $path = \Drupal::service('extension.list.module')->getPathname('stanford_media') . '/templates';
   $theme_registry['dropzonejs']['path'] = $path;
 }
 

--- a/tests/src/Unit/StanfordMediaTest.php
+++ b/tests/src/Unit/StanfordMediaTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\Tests\stanford_media\Unit;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Utility\LinkGeneratorInterface;
+use Drupal\Core\Utility\UnroutedUrlAssemblerInterface;
+use Drupal\stanford_media\StanfordMedia;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class StanfordMediaTest.
+ *
+ * @coversDefaultClass \Drupal\stanford_media\StanfordMedia
+ * @group stanford_media
+ */
+class StanfordMediaTest extends UnitTestCase {
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $url_assembler = $this->createMock(UnroutedUrlAssemblerInterface::class);
+    $link_generator = $this->createMock(LinkGeneratorInterface::class);
+    $container = new ContainerBuilder();
+    $container->set('unrouted_url_assembler', $url_assembler);
+    $container->set('link_generator', $link_generator);
+    $container->set('string_translation', $this->getStringTranslationStub());
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Test the trusted callbacks.
+   */
+  public function testCallbacks() {
+    $this->assertNotEmpty(StanfordMedia::trustedCallbacks());
+
+    $element = ['alt' => ['#description' => 'Foo Bar Baz']];
+    $form_state = new FormState();
+    $form = [];
+
+    $new_element = StanfordMedia::imageWidgetProcess($element, $form_state, $form);
+    $this->assertNotEmpty($new_element);
+    $this->assertStringContainsString('Leave blank if image is decorative', (string) $new_element['alt']['#description']);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Alter the alt text field help text for images.

# Need Review By (Date)
- 1/20

# Urgency
- low

# Steps to Test
1. checkout this branch
2. clear caches
3. go to upload or edit an image media item
4. validate the help text on the alt field is different and contains a link to the uit website.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
