### PR TITLE
D8CORE-5410 Apply the modified alt help text to embedded images

### DIFF
--- a/src/Plugin/MediaEmbedDialog/Image.php
+++ b/src/Plugin/MediaEmbedDialog/Image.php
@@ -6,6 +6,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\media\MediaInterface;
 use Drupal\stanford_media\Plugin\MediaEmbedDialogBase;
 use Drupal\media\Plugin\media\Source\Image as ImageSource;
+use Drupal\stanford_media\StanfordMedia;
 
 /**
  * Changes embedded Image media form.
@@ -53,6 +54,7 @@ class Image extends MediaEmbedDialogBase {
       return;
     }
 
+    $form['#process'][] = [StanfordMedia::class, 'imageWidgetProcess'];
     // Allow a user to edit the caption text in the modal.
     $form['caption_text'] = [
       '#type' => 'textarea',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Modify the alt help text when embedding an image in the WYSIWYG

# Need Review By (Date)
- 3/5

# Urgency
- low

# Steps to Test
1. checkout this branch
2. embed an image into a wysiwyg
3. click the "Edit This Media" button in the WYSIWYG
4. verify the alt text help text has changed from the core text.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
