### PR TITLE
D8CORE-5963 Improve "Decorative" approach to images

### DIFF
--- a/src/StanfordMedia.php
+++ b/src/StanfordMedia.php
@@ -17,7 +17,7 @@ class StanfordMedia implements TrustedCallbackInterface {
    * {@inheritDoc}
    */
   public static function trustedCallbacks() {
-    return ['imageWidgetProcess'];
+    return ['imageWidgetProcess', 'imageWidgetValue'];
   }
 
   /**
@@ -39,7 +39,45 @@ class StanfordMedia implements TrustedCallbackInterface {
       $link = Link::fromTextAndUrl($url->toString(), $url)->toString();
       $element['alt']['#description'] = new TranslatableMarkup('Short description of the image used by screen readers and displayed when the image is not loaded. Leave blank if image is decorative. Learn more about alternative text: @link', ['@link' => $link]);
     }
+
+    $element['decorative'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Decorative Image'),
+      '#description' => t('Check this only if the image presents no additional information to the viewer.'),
+      '#weight' => -99,
+      '#default_value' => empty($element['alt']['#default_value']),
+      '#attributes' => ['data-decorative' => true],
+    ];
+    $element['alt']['#states']['visible'][':input[data-decorative]']['checked'] = FALSE;
+    $element['alt']['#value_callback'] = [self::class, 'imageAltValue'];
     return $element;
+  }
+
+  /**
+   * Image alt text field value callback.
+   *
+   * @param array $element
+   *   Form element.
+   * @param string|bool $input
+   *   User entered value.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Current form state.
+   *
+   * @return string
+   *   Adjusted input string.
+   */
+  public static function imageAltValue(array &$element, $input, FormStateInterface $form_state) {
+    if ($input === FALSE) {
+      return $element['#default_value'];
+    }
+    $parents = array_slice($element['#parents'], 0, -1);
+    $decorative_path = $parents;
+    $decorative_path[] = 'decorative';
+    if ($form_state->getValue($decorative_path)) {
+      $form_state->setValue($element['#parents'], '');
+      return '';
+    }
+    return $input;
   }
 
 }

--- a/src/StanfordMedia.php
+++ b/src/StanfordMedia.php
@@ -39,6 +39,9 @@ class StanfordMedia implements TrustedCallbackInterface {
       $link = Link::fromTextAndUrl($url->toString(), $url)->toString();
       $element['alt']['#description'] = new TranslatableMarkup('Short description of the image used by screen readers and displayed when the image is not loaded. Leave blank if image is decorative. Learn more about alternative text: @link', ['@link' => $link]);
     }
+    if ($element['#alt_field_required'] || !$element['alt']['#access']) {
+      return $element;
+    }
 
     $element['decorative'] = [
       '#type' => 'checkbox',
@@ -46,10 +49,11 @@ class StanfordMedia implements TrustedCallbackInterface {
       '#description' => t('Check this only if the image presents no additional information to the viewer.'),
       '#weight' => -99,
       '#default_value' => empty($element['alt']['#default_value']),
-      '#attributes' => ['data-decorative' => true],
+      '#attributes' => ['data-decorative' => TRUE],
     ];
     $element['alt']['#states']['visible'][':input[data-decorative]']['checked'] = FALSE;
     $element['alt']['#value_callback'] = [self::class, 'imageAltValue'];
+
     return $element;
   }
 

--- a/tests/src/Unit/StanfordMediaTest.php
+++ b/tests/src/Unit/StanfordMediaTest.php
@@ -37,7 +37,10 @@ class StanfordMediaTest extends UnitTestCase {
   public function testCallbacks() {
     $this->assertNotEmpty(StanfordMedia::trustedCallbacks());
 
-    $element = ['alt' => ['#description' => 'Foo Bar Baz']];
+    $element = [
+      '#alt_field_required' => FALSE,
+      'alt' => ['#access' => TRUE, '#description' => 'Foo Bar Baz'],
+    ];
     $form_state = new FormState();
     $form = [];
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add a "Decorative" checkbox on image fields in the media library to enforce empty alt texts
- Allow "unsetting" an alt text in the wysiwyg for decorative images.

# Need Review By (Date)
- 7/7

# Urgency
- Medium

# Steps to Test
1. checkout this branch
2. Go to create an image via the media library or the wysiwyg
3. try out the "Decorative image" checkbox
4. create an image with an alt text and add it to the media library.
5. in a wysiwyg, add that image to the body
6. edit the inline image and set it to be decorative
7. save the page
8. verify the image has an empty alt attribute.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
