### PR TITLE
HSD8-1338 Add twitter embed code validator

### DIFF
--- a/src/Plugin/EmbedValidator/TwitterValidator.php
+++ b/src/Plugin/EmbedValidator/TwitterValidator.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\stanford_media\Plugin\EmbedValidator;
+
+use Drupal\stanford_media\Plugin\EmbedValidatorBase;
+
+/**
+ * Twitter validation.
+ *
+ * @EmbedValidator (
+ *   id = "twitter",
+ *   label = "Twitter"
+ * )
+ */
+class TwitterValidator extends EmbedValidatorBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function isEmbedCodeAllowed(string $code): bool {
+    $code = self::prepareEmbedCode($code);
+    return !empty($code);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function prepareEmbedCode(string $code): string {
+    // Strip out a bunch of stuff we don't care about.
+    $code = preg_replace("/\r\n|\r|\n/", '', strip_tags($code, '<blockquote> <script> <a> <p>'));
+
+    // The twitter widget script keys off of the class name with twitter- for
+    // the prefix. Like twitter-tweet, twitter-timline, etc. We need to grab
+    // the element that has that class and then we will retain everything within
+    // that element.
+    preg_match('/<(\w+) .*?class="twitter-(.*?)".*?>/', $code, $twitter_container);
+
+    // There should only be 1 <script> tag with the twitter domain.
+    preg_match('/<script.*?src="(.*platform\.twitter\.com.*?)".*?>/', $code, $script_matches);
+    if (!isset($twitter_container[1])  || !isset($script_matches[0])) {
+      return '';
+    }
+
+    // Grab the twitter container that we found earlier.
+    preg_match('/<' . $twitter_container[1] . '.*?\/' . $twitter_container[1] . '>/', $code, $container);
+
+    // Combine the container with the script element.
+    return reset($container) . reset($script_matches) . '</script>';
+  }
+
+}

--- a/tests/src/Unit/Plugin/EmbedValidator/AirtableValidatorTest.php
+++ b/tests/src/Unit/Plugin/EmbedValidator/AirtableValidatorTest.php
@@ -33,7 +33,7 @@ class AirtableValidatorTest extends UnitTestCase {
    */
   public function testAllowed() {
     $this->assertFalse($this->plugin->isEmbedCodeAllowed(''));
-    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.airtable.com></script>'));
+    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.twitter.com"></script>'));
     $this->assertFalse($this->plugin->isEmbedCodeAllowed('<iframe data-foo="foo" src="http://foobar.com">'));
     $this->assertTrue($this->plugin->isEmbedCodeAllowed('<div><iframe data-foo="bar" src="https://airtable.com/foo-bar" title="test embed" ></iframe>'));
   }

--- a/tests/src/Unit/Plugin/EmbedValidator/GoogleIframeValidatorTest.php
+++ b/tests/src/Unit/Plugin/EmbedValidator/GoogleIframeValidatorTest.php
@@ -32,7 +32,7 @@ class GoogleIframeValidatorTest extends UnitTestCase {
    */
   public function testAllowed() {
     $this->assertFalse($this->plugin->isEmbedCodeAllowed(''));
-    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.airtable.com></script>'));
+    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.airtable.com"></script>'));
     $this->assertFalse($this->plugin->isEmbedCodeAllowed('<iframe data-foo="foo" src="http://foobar.com">'));
     $this->assertTrue($this->plugin->isEmbedCodeAllowed('<div><iframe data-foo="bar" src="https://foobar.google.com/foo-bar" title="test embed"></iframe>'));
   }

--- a/tests/src/Unit/Plugin/EmbedValidator/LocalistValidatorTest.php
+++ b/tests/src/Unit/Plugin/EmbedValidator/LocalistValidatorTest.php
@@ -33,7 +33,7 @@ class LocalistValidatorTest extends UnitTestCase {
    */
   public function testAllowed() {
     $this->assertFalse($this->plugin->isEmbedCodeAllowed(''));
-    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.enterprise.localist.com></script>'));
+    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.enterprise.localist.com"></script>'));
     $this->assertFalse($this->plugin->isEmbedCodeAllowed('<div id="localist-widget-1234"><script src="foo.bar"></script>'));
     $this->assertTrue($this->plugin->isEmbedCodeAllowed('<div id="localist-widget-1234"></div><script src="stanford.enterprise.localist.com"></script>'));
   }

--- a/tests/src/Unit/Plugin/EmbedValidator/OutlookCalendarValidatorTest.php
+++ b/tests/src/Unit/Plugin/EmbedValidator/OutlookCalendarValidatorTest.php
@@ -33,7 +33,7 @@ class OutlookCalendarValidatorTest extends UnitTestCase {
    */
   public function testAllowed() {
     $this->assertFalse($this->plugin->isEmbedCodeAllowed(''));
-    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.airtable.com></script>'));
+    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.airtable.com"></script>'));
     $this->assertFalse($this->plugin->isEmbedCodeAllowed('<iframe data-foo="foo" src="http://foobar.com">'));
     $this->assertTrue($this->plugin->isEmbedCodeAllowed('<div><iframe data-foo="bar" src="https://outlook.office365.com/foo-bar" title="test embed"></iframe>'));
   }

--- a/tests/src/Unit/Plugin/EmbedValidator/SharepointDocumentValidatorTest.php
+++ b/tests/src/Unit/Plugin/EmbedValidator/SharepointDocumentValidatorTest.php
@@ -34,7 +34,7 @@ class SharepointDocumentValidatorTest extends UnitTestCase {
    */
   public function testAllowed() {
     $this->assertFalse($this->plugin->isEmbedCodeAllowed(''));
-    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.airtable.com></script>'));
+    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.airtable.com"></script>'));
     $this->assertFalse($this->plugin->isEmbedCodeAllowed('<iframe data-foo="foo" src="http://foobar.com">'));
     $this->assertTrue($this->plugin->isEmbedCodeAllowed('<div><iframe data-foo="bar" src="https://office365stanford.sharepoint.com/foo-bar" title="test embed"></iframe>'));
   }

--- a/tests/src/Unit/Plugin/EmbedValidator/SmartsheetValidatorTest.php
+++ b/tests/src/Unit/Plugin/EmbedValidator/SmartsheetValidatorTest.php
@@ -33,7 +33,7 @@ class SmartsheetValidatorTest extends UnitTestCase {
    */
   public function testAllowed() {
     $this->assertFalse($this->plugin->isEmbedCodeAllowed(''));
-    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.airtable.com></script>'));
+    $this->assertFalse($this->plugin->isEmbedCodeAllowed('<script src="stanford.airtable.com"></script>'));
     $this->assertFalse($this->plugin->isEmbedCodeAllowed('<iframe data-foo="foo" src="http://foobar.com">'));
     $this->assertTrue($this->plugin->isEmbedCodeAllowed('<div><iframe data-foo="bar" src="https://app.smartsheet.com/foo-bar" title="test embed"></iframe>'));
   }

--- a/tests/src/Unit/Plugin/EmbedValidator/TwitterValidatorTest.php
+++ b/tests/src/Unit/Plugin/EmbedValidator/TwitterValidatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\Tests\stanford_media\Unit\Plugin\EmbedValidator;
+
+use Drupal\stanford_media\Plugin\EmbedValidator\TwitterValidator;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Test the Twitter embed validator.
+ *
+ * @group stanford_media
+ * @coversDefaultClass \Drupal\stanford_media\Plugin\EmbedValidator\TwitterValidator
+ */
+class TwitterValidatorTest extends UnitTestCase {
+
+  /**
+   * Plugin object.
+   *
+   * @var \Drupal\stanford_media\Plugin\EmbedValidator\TwitterValidator
+   */
+  protected $plugin;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setup(): void {
+    parent::setUp();
+    $this->plugin = new TwitterValidator([], '', []);
+  }
+
+  /**
+   * Only airtable iframe code is allowed.
+   */
+  public function testAllowed() {
+    $link = '<a class="twitter-timeline"></a>';
+    $script = '<script src="//platform.twitter.com/widgets.js"></script>';
+    $this->assertFalse($this->plugin->isEmbedCodeAllowed(''));
+    $this->assertFalse($this->plugin->isEmbedCodeAllowed($script));
+    $this->assertFalse($this->plugin->isEmbedCodeAllowed($link));
+    $this->assertTrue($this->plugin->isEmbedCodeAllowed($link . $script));
+
+    $sample_code = '<blockquote class="twitter-tweet">
+Felis erat varius dolor proin eu orci bibendum <a href="https://twitter.com/hashtag/sample">Suspendisse ac tristique</a>
+  <a href="https://twitter.com/sample/status/123456789123456">July 25, 2022</a>
+</blockquote>
+ <script async src="https://platform.twitter.com/widgets.js" charset="utf-8">
+</script>';
+    $this->assertTrue($this->plugin->isEmbedCodeAllowed($sample_code));
+  }
+
+  /**
+   * Remove everything not necessary for the iframe.
+   */
+  public function testPreparedCode(){
+    $expected  = '<a class="twitter-timeline">Follow this twitter feed.</a><script src="//platform.twitter.com/widgets.js"></script>';
+
+    $this->assertEquals('', $this->plugin->prepareEmbedCode(''));
+    $this->assertEquals('', $this->plugin->prepareEmbedCode('<div id="foo-bar"><script src="foo.bar"></script>'));
+    $this->assertEquals($expected, $this->plugin->prepareEmbedCode('<p><a class="twitter-timeline">Follow this twitter feed.</a><div>some garbage</div><script src="//platform.twitter.com/widgets.js"></script></p><script src="http://foobar.com">should be removed</script>'));
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added twitter embed code validation.

# Review By Eventually

# Criticality
- low

# Urgency
- medium

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. enable the embed validator on the embed code media type
3. go to twitter.com and find some embed code
4. as a site manager, paste the embed code into the media type
5. verify it allows it and the embed code functions as expected on a page.
