### PR TITLE
HSD8-1340 Clean up files when a media item is deleted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         }
     ],
     "require": {
+        "php": ">=8.0",
         "davidbarratt/custom-installer": "~1.0",
         "drupal/core": "^9.3",
         "drupal/dropzonejs": "^2.0@alpha",

--- a/src/StanfordMediaInterface.php
+++ b/src/StanfordMediaInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\stanford_media;
+
+use Drupal\media\MediaInterface;
+
+/**
+ * Interface StanfordMediaInterface.
+ */
+interface StanfordMediaInterface {
+
+  /**
+   * Delete any files associated with this media.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   Media entity.
+   */
+  public function deleteMediaFiles(MediaInterface $media):void;
+
+}

--- a/stanford_media.module
+++ b/stanford_media.module
@@ -20,6 +20,13 @@ use Drupal\stanford_media\Form\MediaLibraryFileUploadForm;
 use Drupal\stanford_media\Form\MediaLibraryGoogleFormForm;
 
 /**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function stanford_media_media_delete(MediaInterface $media) {
+  \Drupal::service('stanford_media')->deleteMediaFiles($media);
+}
+
+/**
  * Implements hook_entity_bundle_field_info_alter().
  */
 function stanford_media_entity_bundle_field_info_alter(&$fields, EntityTypeInterface $entity_type, $bundle) {

--- a/stanford_media.services.yml
+++ b/stanford_media.services.yml
@@ -1,4 +1,7 @@
 services:
+  stanford_media:
+    class: Drupal\stanford_media\StanfordMedia
+    arguments: ['@entity_type.manager', '@file.usage', '@config.factory']
   stanford_media.route_subscriber:
     class: Drupal\stanford_media\Routing\RouteSubscriber
     tags:

--- a/tests/src/Kernel/Form/BulkUploadFormTest.php
+++ b/tests/src/Kernel/Form/BulkUploadFormTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Form\FormState;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\stanford_media\Form\BulkUpload;
+use Drupal\Tests\stanford_media\Kernel\StanfordMediaTestBase;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 
@@ -15,7 +16,7 @@ use Drupal\user\Entity\User;
  * @group stanford_media
  * @coversDefaultClass \Drupal\stanford_media\Form\BulkUpload
  */
-class BulkUploadFormTest extends StanfordMediaFormTestBase {
+class BulkUploadFormTest extends StanfordMediaTestBase {
 
   /**
    * Testing form namespace argument.

--- a/tests/src/Kernel/Form/MediaLibraryEmbeddableFormTest.php
+++ b/tests/src/Kernel/Form/MediaLibraryEmbeddableFormTest.php
@@ -9,6 +9,7 @@ use Drupal\media_library\MediaLibraryState;
 use Drupal\stanford_media\Form\MediaLibraryEmbeddableForm;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Tests\stanford_media\Kernel\StanfordMediaTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 
 /**
@@ -17,7 +18,7 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
  * @group stanford_media
  * @coversDefaultClass \Drupal\stanford_media\Form\MediaLibraryEmbeddableForm
  */
-class MediaLibraryEmbeddableFormTest extends StanfordMediaFormTestBase {
+class MediaLibraryEmbeddableFormTest extends StanfordMediaTestBase {
 
   use UserCreationTrait;
 

--- a/tests/src/Kernel/Form/MediaLibraryFileUploadFormTest.php
+++ b/tests/src/Kernel/Form/MediaLibraryFileUploadFormTest.php
@@ -8,6 +8,7 @@ use Drupal\media\Entity\Media;
 use Drupal\media_duplicate_validation\Plugin\MediaDuplicateValidationManager;
 use Drupal\media_library\MediaLibraryState;
 use Drupal\stanford_media\Form\MediaLibraryFileUploadForm;
+use Drupal\Tests\stanford_media\Kernel\StanfordMediaTestBase;
 
 /**
  * Class MediaLibraryFileUploadFormTest.
@@ -15,7 +16,7 @@ use Drupal\stanford_media\Form\MediaLibraryFileUploadForm;
  * @group stanford_media
  * @coversDefaultClass \Drupal\stanford_media\Form\MediaLibraryFileUploadForm
  */
-class MediaLibraryFileUploadFormTest extends StanfordMediaFormTestBase {
+class MediaLibraryFileUploadFormTest extends StanfordMediaTestBase {
 
   /**
    * Testing form namespace argument.
@@ -107,7 +108,7 @@ class MediaLibraryFileUploadFormTest extends StanfordMediaFormTestBase {
    * @throws \Drupal\Core\Form\FormAjaxException
    */
   public function testEntityFormElement() {
-    list($form, $form_state) = $this->runEntityFormSetup();
+    [$form, $form_state] = $this->runEntityFormSetup();
     $this->assertArrayNotHasKey('similar_media', $form['media'][0]);
   }
 
@@ -120,7 +121,7 @@ class MediaLibraryFileUploadFormTest extends StanfordMediaFormTestBase {
    */
   public function testEntityFormWithSimilar() {
     $this->addDuplicationService();
-    list($form, $form_state) = $this->runEntityFormSetup();
+    [$form, $form_state] = $this->runEntityFormSetup();
     $this->assertCount(4, $form['media'][0]['similar_media'][0]['#options']);
   }
 
@@ -165,7 +166,7 @@ class MediaLibraryFileUploadFormTest extends StanfordMediaFormTestBase {
   public function testValidation() {
     $this->addDuplicationService();
     /** @var \Drupal\Core\Form\FormStateInterface $form_state */
-    list($form, $form_state) = $this->runEntityFormSetup();
+    [$form, $form_state] = $this->runEntityFormSetup();
     $form_state->setValue(['similar_media'], [2]);
     $form_state->getFormObject()->validateForm($form, $form_state);
     $this->assertEquals(2, $form_state->get(['media', 0])->id());

--- a/tests/src/Kernel/Form/MediaLibraryGoogleFormFormTest.php
+++ b/tests/src/Kernel/Form/MediaLibraryGoogleFormFormTest.php
@@ -7,6 +7,7 @@ use Drupal\media\Entity\Media;
 use Drupal\media\Entity\MediaType;
 use Drupal\media_library\MediaLibraryState;
 use Drupal\stanford_media\Form\MediaLibraryGoogleFormForm;
+use Drupal\Tests\stanford_media\Kernel\StanfordMediaTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 
 /**
@@ -15,7 +16,7 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
  * @group stanford_media
  * @coversDefaultClass \Drupal\stanford_media\Form\MediaLibraryGoogleFormForm
  */
-class MediaLibraryGoogleFormFormTest extends StanfordMediaFormTestBase {
+class MediaLibraryGoogleFormFormTest extends StanfordMediaTestBase {
 
   use UserCreationTrait;
 

--- a/tests/src/Kernel/Form/StanfordMediaDialogFormTest.php
+++ b/tests/src/Kernel/Form/StanfordMediaDialogFormTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Form\FormState;
 use Drupal\editor\Entity\Editor;
 use Drupal\filter\Entity\FilterFormat;
 use Drupal\media\Entity\Media;
+use Drupal\Tests\stanford_media\Kernel\StanfordMediaTestBase;
 
 /**
  * Class StanfordMediaDialogFormTest.
@@ -13,7 +14,7 @@ use Drupal\media\Entity\Media;
  * @group stanford_media
  * @coversDefaultClass \Drupal\stanford_media\Form\StanfordMediaDialogForm
  */
-class StanfordMediaDialogFormTest extends StanfordMediaFormTestBase {
+class StanfordMediaDialogFormTest extends StanfordMediaTestBase {
 
   /**
    * {@inheritDoc}

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/MultiMediaFormatterTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/MultiMediaFormatterTest.php
@@ -86,6 +86,7 @@ class MultiMediaFormatterTest extends KernelTestBase {
     $this->installEntitySchema('file');
     $this->installSchema('file', ['file_usage']);
     $this->installEntitySchema('media');
+    $this->installConfig('media');
 
     // Ceate a Date Format.
     DateFormat::create([

--- a/tests/src/Kernel/StanfordMediaTest.php
+++ b/tests/src/Kernel/StanfordMediaTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\Tests\stanford_media\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\media\Entity\Media;
+
+/**
+ * Tests for the stanford media service.
+ *
+ * @coversDefaultClass \Drupal\stanford_media\StanfordMedia
+ */
+class StanfordMediaTest extends StanfordMediaTestBase {
+
+  /**
+   * Media deletion should delete the associated file from the server.
+   */
+  public function testFileDelete() {
+
+    $source_field = $this->mediaType->getSource()
+      ->getSourceFieldDefinition($this->mediaType)
+      ->getName();
+
+    $file_uri = 'temporary://testfile.txt';
+    /** @var \Drupal\file\FileInterface $file */
+    $file = File::create(['uri' => $file_uri]);
+    $file->save();
+    $media = Media::create([
+      'bundle' => 'file',
+      $source_field => ['target_id' => $file->id()],
+    ]);
+    $media->save();
+    $this->assertTrue(file_exists($file->getFileUri()));
+
+    $media->delete();
+    $this->assertFalse(file_exists($file->getFileUri()));
+  }
+
+}

--- a/tests/src/Kernel/StanfordMediaTestBase.php
+++ b/tests/src/Kernel/StanfordMediaTestBase.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Drupal\Tests\stanford_media\Kernel\Form;
+namespace Drupal\Tests\stanford_media\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\media\Entity\MediaType;
 
-abstract class StanfordMediaFormTestBase extends KernelTestBase {
+abstract class StanfordMediaTestBase extends KernelTestBase {
 
   /**
    * {@inheritDoc}
@@ -39,6 +39,7 @@ abstract class StanfordMediaFormTestBase extends KernelTestBase {
     $this->installSchema('file', ['file_usage']);
     $this->installSchema('system', ['sequences']);
     $this->installConfig('system');
+    $this->installConfig('media');
 
     $this->mediaType = MediaType::create([
       'name' => 'file',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Delete associated files from the server if the media item is deleted
- It will also delete thumbnails that might be different such as when a video media is deleted.

# Review By :shrug: 

# Criticality
- medium

# Urgency
- medium

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. clear caches
3. create a media item and upload images/files
4. view the file list page to see your files. `/admin/content/files`
5. delete the media item
6. reload the file list page
7. verify your file has been removed.
