### PR TITLE
Add missing jQuery and Drupal dependencies to display library

### DIFF
--- a/stanford_media.libraries.yml
+++ b/stanford_media.libraries.yml
@@ -13,4 +13,6 @@ display:
   js:
     js/stanford-media.js: {}
   dependencies:
+    - core/drupal
+    - core/jquery
     - core/once


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add the missing `core/drupal` and `core/jquery` dependencies to the `display` library so `js/stanford-media.js` loads after the globals it references. This fixes the anonymous/aggregated load-order failure where `jQuery is not defined` can break oEmbed-driven slider behavior.

# Review By (Date)
- TBD

# Criticality
- 7
- This affects frontend behavior for anonymous users when assets are aggregated. Impact can extend to any site using the `display` library path in this module, but the reported regression is on H&S-hosted sites using slider-related media behavior.

# Urgency
- Medium

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild caches `drush cr`
3. Visit a page that renders `stanford_media` display output with oEmbed/slider behavior as an anonymous user
4. Verify the page no longer throws `jQuery is not defined` from `js/stanford-media.js`
5. Verify the affected media/slider UI renders and functions for anonymous users

# Affected Projects or Products
- `stanford_media` module consumers that use the `display` library, especially pages where anonymous users receive aggregated JS and the media UI depends on `js/stanford-media.js`

# Associated Issues and/or People
- JIRA ticket(s): HSD8-1896
- Other PRs: downstream application patch will be generated from this change for non-Drupal-11.3 consumers
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.): This is the upstream version of the one-line dependency fix for the anonymous slider/oEmbed regression. The bug reproduces as `Uncaught ReferenceError: jQuery is not defined` in `js/stanford-media.js` when the library is loaded without a declared jQuery dependency.